### PR TITLE
Deploy tagged Windows/macOS builds to GitHub Releases (WIP)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+sudo: false
+language: node_js
+node_js:
+  - "6"
+  - "stable"
+
+os:
+  - osx
+
+# latest npm
+before_install:
+  - npm install -g npm
+
+script:
+  - node bin/package_macos.js
+  - node bin/create_macos_dmg.js
+
+deploy:
+  skip_cleanup: true
+  provider: releases  # github releases
+  file_glob: true
+  file: "dist/Mapeo-darwin-x64/Mapeo-v*.dmg"
+  on:
+    tags: true
+  api_key:
+    secure: "2ZHJN10sBsT4Myw8GJCn30/tK1R7lHrgIOka3ycVjr/Nz6KV2X4fV9NJ1Npgypt9sd7rqicW+vhHZcEsMe1nOF+PpFhhaRs74I5h1NV3Qd1mukb/9wYWwX0SMWw2x0dRxrzeGpULzwwHgQ5RmlQ5RQYTfXjMp4ZUD0nULetHUP/b5fuIEznJlk8Oe3WwdoRkRvkXe9/xG1rHQLnSQy2B3e74fTEI444jpAbE3BrziSzKYM6UxsrnFhNWxrc6NIRxEmmcAIrFTsuXGc363RHOwJVx/36NK3U8w5HtUE1r1w9+WjAZiCiibZPYKr6pYKIx3hoOiBH7HmjWlLAgUOBDU+rzBKD5f3GNdL595N54Vtp0/6XGRS92QYmXKxV1STTot33MdUEwPSoEpRhhcagOqa99wqDg9qgMx+hYsd5Ddxm+1TjOErVjnDHF148fKjugtXiRFdEAsrM0bY1D1HqMuTT+A4GT0iDH8ESDhDM6dqISfR1dGHx5xWgxcIM1ArDlynnSYhDXSfixr8Hc6fA/obXOz0IsgKVIdWRlvmM7mIBUKJFJtq8s4xKfRFT0dMNLrVlImhuv9tP9qvCgKH4qrq+RDHJsyZDPmVrFMDwPeXD/mlrnIhSvDt7/kZ1WJ2MZMnHM7mq0bwg6mf4H24a+2RRT+JqSWFa4Ty42vz0UznA="
+

--- a/README.md
+++ b/README.md
@@ -1,24 +1,31 @@
-# mapeo-desktop
+# Mapeo Desktop
 
-An _experimental_ offline mapping app for indigenous territory mapping in remote environments. It uses [osm-p2p](https://github.com/digidem/osm-p2p-db) for offline peer-to-peer synchronization of an OpenStreetMap database, without any server. The editor is based on [iDEditor](https://github.com/openstreetmap/iD/), a simple and easy to use editor for OpenStreetMap. The app is web app built with [Electron](http://electron.atom.io) for desktop integration and offline usage.
+An _experimental_ offline mapping app for indigenous territory mapping in remote
+environments. It uses [osm-p2p](https://github.com/digidem/osm-p2p-db) for
+offline peer-to-peer synchronization of an OpenStreetMap database, without any
+server. The editor is based on [iDEditor](https://github.com/openstreetmap/iD/),
+a simple and easy to use editor for OpenStreetMap. The app is web app built with
+[Electron](http://electron.atom.io) for desktop integration and offline usage.
 
-This project is under active development and is still at the prototype phase, although we are already testing it out in the field in Ecuador.
+This project is under active development and is still at the prototype phase,
+although we are already testing it out in the field in Ecuador.
 
-# getting started
+# Getting Started
 
-To clone and install all dependencies and run the server, do:
+To clone and install all dependencies and start the program, execute
 
 ```
 $ git clone git@github.com:digidem/mapeo-desktop.git
 $ cd mapeo-desktop
 $ npm install
 $ npm run build
+$ npm run rebuild-leveldb
 $ npm start
 ```
 
-# development
+# Local Development
 
-To run the application with debugging enabled, do:
+To run the application with debugging enabled, execute
 
 ```
 $ npm run dev
@@ -26,26 +33,59 @@ $ npm run dev
 
 # Packaging
 
-To package the app as a mac osx or windows app:
+Mapeo uses [Electron](http://electron.atom.io/). To package the Electron app as
+a native Windows `.exe` or macOS `.dmg`, execute
 
 ```
-$ npm run package-win
-$ npm run package-mac
+$ npm run installer-win
+```
+or
+```
+$ npm run dmg-mac
 ```
 
-Build files will be in the `./dist` folder. Note that we do not yet create a windows installer, the folder needs to be copied manually to `C:\Program Files` and you will need to set up manual shortcuts for the start menu.
+The resultant installer or DMG will be placed in the `./dist` folder.
 
-# custom imagery
+# Creating a Release
 
-To add local tiles for offline use, copy or symlink a folder of tiles into 'tiles' within the app's folder in your application directory, which by default points to:
+Mapeo uses [GitHub Releases](https://help.github.com/articles/about-releases/)
+for deployment.
 
-- %APPDATA% on Windows
-- $XDG_CONFIG_HOME or ~/.config on Linux
-- ~/Library/Application Support on OS X
+To create a release, simply push a git tag to the repository. A convenient way
+to both advance the project by a version *and* push a tag is using the `npm
+version` command. To create a new minor version and push it to the github
+repository to initiate a build, one might run
 
-The app folder will be `electron` if you are in development, or the application name (currently "Mapeo") if you are working with the packaged app. E.g. on a mac, copy the folder of image tiles into: `~/Library/Application Support/Mapeo/tiles`
+```
+$ npm version minor
 
-Edit `imagery.json` accordingly with a type of `tms`. The tileserver runs on localhost on port `5005`. For example:
+$ git push --tags
+```
+
+A github release will be created automatically. Simultaneously, an
+[Appveyor](appveyor.yml) build will be started to create a Windows installer,
+and a [Travis](.travis.yml) build will be started for a macOS DMG. Each will be
+added to the github release asynchronously as they complete.
+
+You'll be able to find the results on the project's [releases](../../releases/) page.
+
+# Custom Imagery
+
+To add local tiles for offline use, copy or symlink a folder of tiles into
+'tiles' within the app's folder in your application directory, which by default
+points to:
+
+- `%APPDATA%` on Windows
+- `$XDG_CONFIG_HOME` or `~/.config` on Linux
+- `~/Library/Application Support` on macOS
+
+The app folder will be `electron` if you are in development, or the application
+name (currently "Mapeo") if you are working with the packaged app. E.g. on a
+mac, copy the folder of image tiles into: `~/Library/Application
+Support/Mapeo/tiles`
+
+Edit `imagery.json` accordingly with a type of `tms`. The tileserver runs on
+localhost on port `5005`. For example:
 
 ``` json
 [
@@ -64,4 +104,10 @@ Edit `imagery.json` accordingly with a type of `tms`. The tileserver runs on loc
 $ ln -s ~/data/guyana_tiles/LC82310582015254LGN00 public/tiles/guyana
 ```
 
-# Custom presets
+# Custom Presets
+
+(coming soon)
+
+# License
+
+MIT

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,12 @@ platform:
 # fetch repository as zip archive
 shallow_clone: true
 
+# skip mapeo-vX.Y.Z tags; we already know they build, since they're created
+# as a result of a deployment completing
+branches:
+  except:
+    - /mapeo-v.*/
+
 artifacts:
   - path: dist/Mapeo-win32-x64
     name: mapeo-win
@@ -39,13 +45,13 @@ build_script:
 test: off
 
 deploy:
-  release: mapeo-v$(appveyor_build_version)
+  release: mapeo-v$(appveyor_build_version)  # also the name of the tag that gets created
   provider: GitHub
   auth_token:
     secure: z8zjHnYUgzuwBjJw26lgwSM2T0SdRIqMUzijaL0e0po7+8/tkBsFC/+0z7MkCRUU
-  artifact: /.*\.nupkg/            # upload all NuGet packages to release assets
+  artifact: /mapeo-win.zip/
   draft: false
   prerelease: false
   on:
-    branch: master                 # release from master branch only
+    branch: /^v/                   # don't match "mapeo-*" tags, otherwise we'll get into a tag loop
     appveyor_repo_tag: true        # deploy on tag push only

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,6 @@
 # Appveyor: for producing and deploying Windows builds
 #------------------------------------------------------
 
-version: 0.1.{build}
-
 # Test against this version of Node.js
 environment:
   nodejs_version: "6.2.1"
@@ -22,7 +20,7 @@ branches:
 artifacts:
   - path: '**\*.nupkg'
     name: nupkg
-  - path: '**\InstallarMapeo.exe'
+  - path: '**\InstallarMapeo*.exe'
     name: exe
 
 cache:
@@ -47,11 +45,13 @@ build_script:
   - npm run rebuild-leveldb
   - npm run package-win
   - npm run installer-win
+  - ps: $PACKAGE_VERSION = node -e "require('./package.json').version"
+  - ps: $env:RELEASE = "${PACKAGE_NAME}-${PACKAGE_VERSION}"
+
 
 test: off
 
 deploy:
-  release: mapeo-v$(appveyor_build_version)  # also the name of the tag that gets created
   provider: GitHub
   auth_token:
     secure: Do48zAyJyqq3Cqu0JLYy/ayhLbNvvDt+j/yZPi6GMIn/dD0t5En/11JFOLMG9c13

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+# Appveyor: for producing and deploying Windows builds
+#------------------------------------------------------
+
 version: 0.1.{build}
 
 # Test against this version of Node.js
@@ -17,8 +20,10 @@ branches:
     - /mapeo-v.*/
 
 artifacts:
-  - path: dist/Mapeo-win32-x64
-    name: mapeo-win
+  - path: '**\*.nupkg'
+    name: nupkg
+  - path: '**\InstallarMapeo.exe'
+    name: exe
 
 cache:
   - '%APPDATA%\npm-cache'
@@ -41,6 +46,7 @@ build_script:
   - npm run build
   - npm run rebuild-leveldb
   - npm run package-win
+  - npm run installer-win
 
 test: off
 
@@ -48,8 +54,7 @@ deploy:
   release: mapeo-v$(appveyor_build_version)  # also the name of the tag that gets created
   provider: GitHub
   auth_token:
-    secure: z8zjHnYUgzuwBjJw26lgwSM2T0SdRIqMUzijaL0e0po7+8/tkBsFC/+0z7MkCRUU
-  artifact: /mapeo-win.zip/
+    secure: Do48zAyJyqq3Cqu0JLYy/ayhLbNvvDt+j/yZPi6GMIn/dD0t5En/11JFOLMG9c13
   draft: false
   prerelease: false
   on:

--- a/bin/create_installer.js
+++ b/bin/create_installer.js
@@ -15,9 +15,13 @@ electronInstaller.createWindowsInstaller({
   outputDirectory: installerFolder,
   description: 'Offline Map Editor',
   authors: 'Digital Democracy',
+  name: 'Mapeo',
   exe: 'Mapeo.exe',
   setupExe: 'InstallarMapeo.exe',
-  iconUrl: 'https://raw.githubusercontent.com/digidem/mapeo-desktop/master/static/mapeo.ico'
+  iconUrl: 'https://raw.githubusercontent.com/digidem/mapeo-desktop/master/static/mapeo.ico',
+  version: '1.2.3-fake',
+  title: 'mapeo',
+  usePackageJson: false
 }).then(function () {
   console.log('It worked!')
 }).catch(function (e) {

--- a/bin/create_macos_dmg.js
+++ b/bin/create_macos_dmg.js
@@ -1,15 +1,15 @@
 var appDmg = require('appdmg')
 var path = require('path')
-var rimrag = require('rimraf')
+var rimraf = require('rimraf')
 
 var config = require('../config')
 
 console.log('OS X: Creating dmg...')
 
-var DIST_PATH = path.join(__dirname, '..', 'dist')
+var DIST_PATH = path.join(__dirname, '..', 'dist', 'Mapeo-darwin-x64')
 var BUILD_NAME = config.APP_NAME + '-v' + config.APP_VERSION
 
-var appPath = path.join(buildPath[0], config.APP_NAME + '.app')
+var appPath = path.join(DIST_PATH, config.APP_NAME + '.app')
 var targetPath = path.join(DIST_PATH, BUILD_NAME + '.dmg')
 rimraf.sync(targetPath)
 
@@ -20,7 +20,7 @@ var dmgOpts = {
   specification: {
     title: config.APP_NAME,
     icon: config.APP_ICON + '.icns',
-    background: path.join(config.STATIC_PATH, 'appdmg.png'),
+    // background: path.join(config.STATIC_PATH, 'appdmg.png'),
     'icon-size': 128,
     contents: [
       { x: 122, y: 240, type: 'file', path: appPath },
@@ -36,11 +36,14 @@ var dmgOpts = {
 }
 
 var dmg = appDmg(dmgOpts)
-dmg.once('error', cb)
+dmg.once('error', function (err) {
+  console.error(err)
+  process.exit(1)
+})
 dmg.on('progress', function (info) {
   if (info.type === 'step-begin') console.log(info.title + '...')
 })
 dmg.once('finish', function (info) {
-  console.log('OS X: Created dmg.')
-  cb(null)
+  console.log('OS X: Created dmg @', targetPath)
+  process.exit(0)
 })

--- a/bin/create_windows_installer.js
+++ b/bin/create_windows_installer.js
@@ -4,6 +4,7 @@ var rimraf = require('rimraf').sync
 var path = require('path')
 
 var distFolder = path.join(__dirname, '..', 'dist')
+var pkg = JSON.parse(require('fs').readFileSync(path.join(__dirname, '..', 'package.json')).toString())
 var buildFolder = path.join(distFolder, 'Mapeo-win32-x64')
 var installerFolder = path.join(distFolder, 'installer-win-x64')
 
@@ -13,15 +14,17 @@ mkdirp(installerFolder)
 electronInstaller.createWindowsInstaller({
   appDirectory: buildFolder,
   outputDirectory: installerFolder,
+
+  usePackageJson: false,
+
   description: 'Offline Map Editor',
   authors: 'Digital Democracy',
   name: 'Mapeo',
   exe: 'Mapeo.exe',
-  setupExe: 'InstallarMapeo.exe',
+  setupExe: 'InstallarMapeo_' + pkg.version + '.exe',
   iconUrl: 'https://raw.githubusercontent.com/digidem/mapeo-desktop/master/static/mapeo.ico',
-  version: '1.2.3-fake',
+  version: pkg.version,
   title: 'mapeo',
-  usePackageJson: false
 }).then(function () {
   console.log('It worked!')
 }).catch(function (e) {

--- a/bin/create_windows_installer.js
+++ b/bin/create_windows_installer.js
@@ -4,7 +4,7 @@ var rimraf = require('rimraf').sync
 var path = require('path')
 
 var distFolder = path.join(__dirname, '..', 'dist')
-var pkg = JSON.parse(require('fs').readFileSync(path.join(__dirname, '..', 'package.json')).toString())
+var pkg = require(path.join('..', 'package.json'))
 var buildFolder = path.join(distFolder, 'Mapeo-win32-x64')
 var installerFolder = path.join(distFolder, 'installer-win-x64')
 
@@ -17,8 +17,8 @@ electronInstaller.createWindowsInstaller({
 
   usePackageJson: false,
 
-  description: 'Offline Map Editor',
-  authors: 'Digital Democracy',
+  description: pkg.productDescription,
+  authors: pkg.author,
   name: 'Mapeo',
   exe: 'Mapeo.exe',
   setupExe: 'InstallarMapeo_' + pkg.version + '.exe',

--- a/bin/package_macos.js
+++ b/bin/package_macos.js
@@ -1,0 +1,48 @@
+var path = require('path')
+var rimraf = require('rimraf').sync
+var spawn = require('cross-spawn').sync
+var packager = require('electron-packager')
+
+var pkg = require(path.join('..', 'package.json'))
+
+// clear old output folder
+var distFolder = path.join(__dirname, '..', 'dist')
+var installerFolder = path.join(distFolder, 'installer-win-x64')
+rimraf(installerFolder)
+
+// run "bin/build_id_editor.js"
+var res = spawn('npm', ['run', 'build:id'])
+if (res.error) {
+  console.log(res.error)
+  process.exit(1)
+}
+if (res.status) {
+  console.log(res.output.toString())
+  process.exit(res.status)
+}
+
+// package electron executable
+packager({
+  dir: '.',
+  arch: 'x64',
+  platform: 'darwin',
+  icon: path.join('static', 'mapeo.icns'),
+  ignore: /^\/dist/,
+  out: 'dist',
+  tmpdir: false,
+  version: pkg.version,
+  'app-version': pkg.version,
+  'build-version': '1.0.0',
+  prune: true,
+  overwrite: true,
+  'app-bundle-id': 'org.digital-democracy.mapeo-desktop',
+  // 'osx-sign': true
+}, function done_callback (err, appPaths) {
+  if (err) {
+    console.error(err)
+    process.exit(1)
+  } else {
+    console.log(appPaths)
+  }
+})
+

--- a/bin/package_windows.js
+++ b/bin/package_windows.js
@@ -1,0 +1,48 @@
+var path = require('path')
+var rimraf = require('rimraf').sync
+var spawn = require('cross-spawn').sync
+var packager = require('electron-packager')
+
+var pkg = require(path.join('..', 'package.json'))
+
+// clear old output folder
+var distFolder = path.join(__dirname, '..', 'dist')
+var installerFolder = path.join(distFolder, 'installer-win-x64')
+rimraf(installerFolder)
+
+// run "bin/build_id_editor.js"
+var res = spawn('npm', ['run', 'build:id'])
+if (res.error) {
+  console.log(res.error)
+  process.exit(1)
+}
+if (res.status) {
+  console.log(res.output.toString())
+  process.exit(res.status)
+}
+
+// package electron exeuctable
+packager({
+  dir: '.',
+  arch: 'x64',
+  platform: 'win32',
+  icon: path.join('static', 'mapeo.ico'),
+  ignore: /^\/dist/,
+  out: 'dist',
+  version: pkg.version,
+  prune: true,
+  overwrite: true,
+  asar: true,
+  'version-string': {
+    ProductName: 'Mapeo',
+    CompanyName: 'Digital Democracy'
+  },
+}, function done_callback (err, appPaths) {
+  if (err) {
+    console.error(err)
+    process.exit(1)
+  } else {
+    console.log(appPaths)
+  }
+})
+

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean": "rimraf \"dist/Mapeo-win32-x64\"",
     "package-win": "node bin/package_windows.js",
     "installer-win": "node bin/create_windows_installer.js",
-    "package-mac": "npm run clean && npm run build:id && electron-packager . \"Mapeo\" --icon=\"static/mapeo.icns\" --out=dist --ignore=\"^/dist\" --tmpdir=false --platform=darwin --arch=x64 --version=1.3.4 --prune --overwrite --app-bundle-id=\"org.digital-democracy.mapeo-desktop\" --app-version=\"1.2.0\" --build-version=\"1.0.0\" --osx-sign",
+    "package-mac": "node bin/package_macos.js",
     "rebuild-leveldb": "cd node_modules/leveldown && cross-env HOME=~/.electron-gyp node-gyp rebuild --target=1.3.4 --runtime=electron --arch=x64 --dist-url=https://atom.io/download/atom-shell",
     "start": "electron app.js --disable-http-cache",
     "server": "node app.js --headless",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm run build:id",
     "build:id": "node bin/build_id_editor.js",
     "package-win": "rimraf \"dist/Mapeo-win32-x64\" && npm run build:id && electron-packager . \"Mapeo\" --icon=\"static/mapeo.ico\" --out=dist --ignore=\"^/dist\" --platform=win32 --arch=x64 --version=1.3.4 --prune --overwrite --asar --version-string.ProductName=Mapeo --version-string.CompanyName=\"Digital Democracy\"",
-    "installer-win": "node bin/create_installer.js",
+    "installer-win": "node bin/create_windows_installer.js",
     "package-mac": "rimraf \"dist/Mapeo-darwin-x64\" && npm run build:id && electron-packager . \"Mapeo\" --icon=\"static/mapeo.icns\" --out=dist --ignore=\"^/dist\" --tmpdir=false --platform=darwin --arch=x64 --version=1.3.4 --prune --overwrite --app-bundle-id=\"org.digital-democracy.mapeo-desktop\" --app-version=\"1.2.0\" --build-version=\"1.0.0\" --osx-sign",
     "rebuild-leveldb": "cd node_modules/leveldown && cross-env HOME=~/.electron-gyp node-gyp rebuild --target=1.3.4 --runtime=electron --arch=x64 --dist-url=https://atom.io/download/atom-shell",
     "start": "electron app.js --disable-http-cache",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "xtend": "^4.0.1"
   },
   "devDependencies": {
-    "appdmg": "^0.4.5",
     "browserify": "^13.0.0",
     "@gmaclennan/concat": "^1.0.0",
     "cross-env": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "description": "An experimental offline mapping app based on iD Editor, for indigenous territory mapping in remote environments",
   "productName": "Mapeo",
   "version": "1.2.2",
+  "productDescription": "Offline Map Editor",
+  "author": "Digital Democracy",
   "main": "app.js",
   "engine": {
     "node": "6.2.1"
@@ -10,9 +12,10 @@
   "scripts": {
     "build": "npm run build:id",
     "build:id": "node bin/build_id_editor.js",
-    "package-win": "rimraf \"dist/Mapeo-win32-x64\" && npm run build:id && electron-packager . \"Mapeo\" --icon=\"static/mapeo.ico\" --out=dist --ignore=\"^/dist\" --platform=win32 --arch=x64 --version=1.3.4 --prune --overwrite --asar --version-string.ProductName=Mapeo --version-string.CompanyName=\"Digital Democracy\"",
+    "clean": "rimraf \"dist/Mapeo-win32-x64\"",
+    "package-win": "node bin/package_windows.js",
     "installer-win": "node bin/create_windows_installer.js",
-    "package-mac": "rimraf \"dist/Mapeo-darwin-x64\" && npm run build:id && electron-packager . \"Mapeo\" --icon=\"static/mapeo.icns\" --out=dist --ignore=\"^/dist\" --tmpdir=false --platform=darwin --arch=x64 --version=1.3.4 --prune --overwrite --app-bundle-id=\"org.digital-democracy.mapeo-desktop\" --app-version=\"1.2.0\" --build-version=\"1.0.0\" --osx-sign",
+    "package-mac": "npm run clean && npm run build:id && electron-packager . \"Mapeo\" --icon=\"static/mapeo.icns\" --out=dist --ignore=\"^/dist\" --tmpdir=false --platform=darwin --arch=x64 --version=1.3.4 --prune --overwrite --app-bundle-id=\"org.digital-democracy.mapeo-desktop\" --app-version=\"1.2.0\" --build-version=\"1.0.0\" --osx-sign",
     "rebuild-leveldb": "cd node_modules/leveldown && cross-env HOME=~/.electron-gyp node-gyp rebuild --target=1.3.4 --runtime=electron --arch=x64 --dist-url=https://atom.io/download/atom-shell",
     "start": "electron app.js --disable-http-cache",
     "server": "node app.js --headless",
@@ -77,6 +80,7 @@
     "browserify": "^13.0.0",
     "@gmaclennan/concat": "^1.0.0",
     "cross-env": "^1.0.8",
+    "cross-spawn": "^4.0.2",
     "devtron": "^1.2.0",
     "electron-packager": "^7.6.0",
     "electron": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "clean": "rimraf \"dist/Mapeo-win32-x64\"",
     "package-win": "node bin/package_windows.js",
     "installer-win": "node bin/create_windows_installer.js",
+    "dmg-mac": "node bin/create_macos_dmg.js",
     "package-mac": "node bin/package_macos.js",
     "rebuild-leveldb": "cd node_modules/leveldown && cross-env HOME=~/.electron-gyp node-gyp rebuild --target=1.3.4 --runtime=electron --arch=x64 --dist-url=https://atom.io/download/atom-shell",
     "start": "electron app.js --disable-http-cache",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "rebuild-leveldb": "cd node_modules/leveldown && cross-env HOME=~/.electron-gyp node-gyp rebuild --target=1.3.4 --runtime=electron --arch=x64 --dist-url=https://atom.io/download/atom-shell",
     "start": "electron app.js --disable-http-cache",
     "server": "node app.js --headless",
-    "dev": "electron app.js --debug --disable-http-cache"
+    "dev": "electron app.js --debug --disable-http-cache",
+    "postinstall": "npmpd"
   },
   "repository": {
     "type": "git",
@@ -36,7 +37,8 @@
   ],
   "contributors": [
     "substack",
-    "Gregor MacLennan <gmaclennan@digital-democracy.org>"
+    "Gregor MacLennan <gmaclennan@digital-democracy.org>",
+    "noffle"
   ],
   "license": "MIT",
   "bugs": {
@@ -45,6 +47,7 @@
   "homepage": "https://github.com/digidem/mapeo-desktop#readme",
   "dependencies": {
     "JSONStream": "^1.0.3",
+    "application-config": "^1.0.1",
     "application-config-path": "^0.1.0",
     "body": "^5.1.0",
     "concat-stream": "^1.5.1",
@@ -76,17 +79,21 @@
     "xhr": "^2.2.0",
     "xtend": "^4.0.1"
   },
+  "darwinDependencies": {
+    "appdmg": "0.4.5"
+  },
   "devDependencies": {
-    "browserify": "^13.0.0",
     "@gmaclennan/concat": "^1.0.0",
+    "browserify": "^13.0.0",
     "cross-env": "^1.0.8",
     "cross-spawn": "^4.0.2",
     "devtron": "^1.2.0",
-    "electron-packager": "^7.6.0",
     "electron": "1.3.4",
+    "electron-packager": "^7.6.0",
     "fs-extra": "^0.30.0",
     "iD": "openstreetmap/iD#v1.9.6",
     "mkdirp": "^0.5.1",
+    "npm-platform-dependencies": "0.0.12",
     "rimraf": "^2.5.2",
     "watchify": "^3.7.0"
   }


### PR DESCRIPTION
## New deployment workflow

The deployment workflow for this configuration is as follows,

1. Tag a new version (e.g. 'npm version patch')
2. Push to the Github repo (e.g. 'git push origin master')

From here, Appveyor will pick up the tag, build the release and create a
new GitHub Release with the binary asset attached.

---

## TODO
- [x] Windows
 - [x] Trigger builds via `git push`ing a tag
 - [x] build artifacts are pushed to a GitHub Release
 - [x] Windows installer is packaged + included
 - [x] Installer version pulled from `package.json`
 - [x] Make appveyor release version match `package.json`
 - [x] Node script for Windows packaging
 - [x] Thread `package.json` version through electron packaging
- [x] macOS
 - [x] Node script for macOS packaging
 - [x] Basic Travis setup for macOS
 - [x] Bundling of mac build into a DMG
 - [x] Deployment of DMG to Github Releases when tagged
- [x] Documentation
 - [x] Update README with build & deploy process
