### PR TITLE
Use electron@1.3.4 for Win/Mac packaging, too.

### DIFF
--- a/bin/package_macos.js
+++ b/bin/package_macos.js
@@ -30,7 +30,7 @@ packager({
   ignore: /^\/dist/,
   out: 'dist',
   tmpdir: false,
-  version: pkg.version,
+  version: '1.3.4',
   'app-version': pkg.version,
   'build-version': '1.0.0',
   prune: true,

--- a/bin/package_windows.js
+++ b/bin/package_windows.js
@@ -29,7 +29,7 @@ packager({
   icon: path.join('static', 'mapeo.ico'),
   ignore: /^\/dist/,
   out: 'dist',
-  version: pkg.version,
+  version: '1.3.4',
   prune: true,
   overwrite: true,
   asar: true,


### PR DESCRIPTION
`version` is for the **Electron** version, not the app version.