### PR TITLE
Add OS-specific suffix to installer filenames.

### DIFF
--- a/bin/create_macos_dmg.js
+++ b/bin/create_macos_dmg.js
@@ -7,10 +7,10 @@ var config = require('../config')
 console.log('OS X: Creating dmg...')
 
 var DIST_PATH = path.join(__dirname, '..', 'dist', 'Mapeo-darwin-x64')
-var BUILD_NAME = config.APP_NAME + '-v' + config.APP_VERSION
+var BUILD_NAME = 'Installar_' + config.APP_NAME + '_v' + config.APP_VERSION
 
 var appPath = path.join(DIST_PATH, config.APP_NAME + '.app')
-var targetPath = path.join(DIST_PATH, BUILD_NAME + '.dmg')
+var targetPath = path.join(DIST_PATH, BUILD_NAME + '_macOS.dmg')
 rimraf.sync(targetPath)
 
 // Create a .dmg (OS X disk image) file, for easy user installation.

--- a/bin/create_windows_installer.js
+++ b/bin/create_windows_installer.js
@@ -21,7 +21,7 @@ electronInstaller.createWindowsInstaller({
   authors: pkg.author,
   name: 'Mapeo',
   exe: 'Mapeo.exe',
-  setupExe: 'InstallarMapeo_' + pkg.version + '.exe',
+  setupExe: 'Installar_Mapeo_' + pkg.version + '_Windows.exe',
   iconUrl: 'https://raw.githubusercontent.com/digidem/mapeo-desktop/master/static/mapeo.ico',
   version: pkg.version,
   title: 'mapeo',


### PR DESCRIPTION
Windows: `Installar_Mapeo_vX.Y.Z_Windows.exe`
macOS: `Installar_Mapeo_vX.Y.Z_macOS.dmg`