### PR TITLE
Use single file tar.gz sneakernet replication.

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,18 +93,37 @@ function ready () {
 
   require('./lib/user-config')
 
-  ipc.on('open-dir', function () {
+  ipc.on('save-file', function () {
+    electron.dialog.showSaveDialog(win, {
+      title: 'Select .mapeodata file for replication',
+      defaultPath: 'sync.mapeodata',
+      filters: [
+        { name: 'Mapeo Data', extensions: ['mapeodata'] },
+      ]
+    }, onopen)
+
+    function onopen (filename) {
+      console.log('1 save-file', filename)
+      if (typeof filename === 'undefined') return
+      console.log('2 save-file', filename)
+      win.webContents.send('select-file', filename)
+    }
+  })
+
+  ipc.on('open-file', function () {
     electron.dialog.showOpenDialog(win, {
-      title: 'select USB media for replication',
-      properties: [ 'openDirectory' ],
-      filters: []
+      title: 'Select .mapeodata file for replication',
+      properties: [ 'openFile' ],
+      filters: [
+        { name: 'Mapeo Data', extensions: ['mapeodata'] },
+      ]
     }, onopen)
 
     function onopen (filenames) {
       if (typeof filenames === 'undefined') return
       if (filenames.length === 1) {
-        var dir = filenames[0]
-        win.webContents.send('select-dir', dir)
+        var file = filenames[0]
+        win.webContents.send('select-file', file)
       }
     }
   })

--- a/browser/sync.js
+++ b/browser/sync.js
@@ -23,7 +23,8 @@ pump(ws, split(JSON.parse), through.obj(function (row, enc, next) {
     resdiv.innerHTML = '<strong>Sinconización se ha completado exitosamente.</strong><br/>' +
       'Ya debes tener la información más reciente en tu mapa. ' +
       'Haga un click en "OK" para volver al mapa'
-    selectBtn.classList.add('hidden')
+    selectExistingBtn.classList.add('hidden')
+    selectNewBtn.classList.add('hidden')
     cancelBtn.classList.remove('hidden')
     cancelBtn.classList.add('btn-primary')
     cancelBtn.innerText = 'OK'
@@ -35,16 +36,16 @@ function onerror (err) { console.error(err) }
 
 var resdiv = document.getElementById('response')
 var cancelBtn = document.getElementById('cancel')
-var selectBtn = document.getElementById('select')
-var buttonText = document.getElementById('button-text')
+var selectExistingBtn = document.getElementById('select-existing')
+var selectNewBtn = document.getElementById('select-new')
 var sourceField = document.querySelector('form#sync input[name="source"]')
 
-ipc.on('select-dir', function (event, dir) {
-  if (!dir) return
-  sourceField.value = dir
-  selectBtn.setAttribute('disabled', 'disabled')
+ipc.on('select-file', function (event, file) {
+  if (!file) return
+  sourceField.value = file
+  selectExistingBtn.setAttribute('disabled', 'disabled')
+  selectNewBtn.setAttribute('disabled', 'disabled')
 
-  buttonText.innerText = 'Sincronizando…'
   xhr({
     method: 'POST',
     url: 'http://' + osmServerHost + '/replicate',
@@ -57,9 +58,14 @@ ipc.on('select-dir', function (event, dir) {
   }, onpost)
 })
 
-selectBtn.addEventListener('click', function (ev) {
+selectExistingBtn.addEventListener('click', function (ev) {
   ev.preventDefault()
-  ipc.send('open-dir')
+  ipc.send('open-file')
+})
+
+selectNewBtn.addEventListener('click', function (ev) {
+  ev.preventDefault()
+  ipc.send('save-file')
 })
 
 cancelBtn.addEventListener('click', function (ev) {
@@ -68,9 +74,9 @@ cancelBtn.addEventListener('click', function (ev) {
 
 function showButtons () {
   document.querySelector('.lead').classList.remove('hidden')
-  selectBtn.removeAttribute('disabled')
+  selectExistingBtn.removeAttribute('disabled')
+  selectNewBtn.removeAttribute('disabled')
   cancelBtn.classList.remove('hidden')
-  buttonText.innerText = 'Seleccionar Archivo…'
 }
 
 function onpost (err, res, body) {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "electron-winstaller": "^2.3.1",
     "end-of-stream": "^1.1.0",
     "hyperlog": "^4.10.0",
+    "hyperlog-sneakernet-replicator": "^1.1.2",
     "insert-css": "^1.0.0",
     "level": "^1.4.0",
     "levelup": "^1.3.1",

--- a/replicate.html
+++ b/replicate.html
@@ -37,8 +37,11 @@
                 <p class="text-right">
                   <input type="hidden" name="source">
                   <button id="cancel" type="button" class="btn btn-default btn-lg">Cancelar</button>
-                  <button id="select" type="button" class="btn btn-primary btn-lg">
-                  <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>&nbsp; <span id="button-text">Seleccionar Archivo&hellip;</span>
+                  <button id="select-new" type="button" class="btn btn-primary btn-lg">
+                    <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>&nbsp; <span id="button-text">Crear Archivo&hellip;</span>
+                  </button>
+                  <button id="select-existing" type="button" class="btn btn-primary btn-lg">
+                    <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>&nbsp; <span id="button-text">Abierto Archivo&hellip;</span>
                   </button>
                 </p>
               </form>


### PR DESCRIPTION
This modifies the sync logic to use hyperlog-sneakernet-replicator,
which performs hyperlog replication between a log and a single gzipped
tarball.

In terms of the sync user interface, this meant adding an additional
button ('Create File'), to differentiate between selecting an existing
.mapeodata to sync to, and creating a new one. One dialog would be
ideal, but Electron doesn't offer a nice Dialog API for this.