### PR TITLE
Remove 5000ms delay on post-sync indexing.

### DIFF
--- a/server.js
+++ b/server.js
@@ -208,12 +208,10 @@ module.exports = function (osm) {
       if (err) return syncErr(err)
       replicating = false
       send('replication-data-complete')
-      setTimeout(function () {
-        osm.ready(function () {
-          console.log('COMPLETE')
-          send('replication-complete')
-        })
-      }, 5000) // HACK, figure out how to not do this in the future
+      osm.ready(function () {
+        console.log('COMPlETE')
+        send('replication-complete')
+      })
     }
     function syncErr (err) {
       replicating = false


### PR DESCRIPTION
I got the impression from @gmaclennan and @substack that the underlying hyperlog issues that necessitated this hack have since been fixed.

My thinking here was that the delay hack (https://github.com/digidem/mapeo-desktop/commit/8ac48490317c56bedd4897b91d41fc5ea914ac18) was written on Mar 16, and [this bugfix on hyperlog events](https://github.com/mafintosh/hyperlog/pull/19) was submitted on Apr 11. Was that PR to address this issue, @substack?

If not, I'd be interested in hearing more about the kinds of case where you two noticed the indexer's `ready` failing to fire. Thanks!
