### PR TITLE
Use dataset_id to filter sync files.

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,8 @@ var electron = require('electron')
 var app = electron.app  // Module to control application life.
 var Menu = electron.Menu
 var BrowserWindow = electron.BrowserWindow  // Module to create native browser window.
-var presets = require('./vendor/iD/presets.json')
+var userConfig = require('./lib/user-config')
+var metadata = userConfig.getSettings('metadata')
 
 var menuTemplate = require('./lib/menu')
 
@@ -95,12 +96,12 @@ function ready () {
   require('./lib/user-config')
 
   ipc.on('save-file', function () {
-    var ext = presets.metadata ? presets.metadata.dataset_id : 'mapeodata'
+    var ext = metadata ? metadata.dataset_id : 'mapeodata'
     electron.dialog.showSaveDialog(win, {
       title: 'Crear nuevo base de datos para sincronizar',
-      defaultPath: 'base-de-datos-mapeo.mapeodata',
+      defaultPath: 'base-de-datos-mapeo.' + ext,
       filters: [
-        { name: 'Mapeo Data', extensions: [ext] },
+        { name: 'Mapeo Data (*.' + ext + ')', extensions: [ext] },
       ]
     }, onopen)
 
@@ -113,12 +114,12 @@ function ready () {
   })
 
   ipc.on('open-file', function () {
-    var ext = presets.metadata ? presets.metadata.dataset_id : 'mapeodata'
+    var ext = metadata ? metadata.dataset_id : 'mapeodata'
     electron.dialog.showOpenDialog(win, {
       title: 'Seleccionar base de datos para sincronizar',
       properties: [ 'openFile' ],
       filters: [
-        { name: 'Mapeo Data', extensions: [ext] },
+        { name: 'Mapeo Data (*.' + ext + ')', extensions: [ext] },
       ]
     }, onopen)
 

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ var electron = require('electron')
 var app = electron.app  // Module to control application life.
 var Menu = electron.Menu
 var BrowserWindow = electron.BrowserWindow  // Module to create native browser window.
+var presets = require('./vendor/iD/presets.json')
 
 var menuTemplate = require('./lib/menu')
 
@@ -94,11 +95,12 @@ function ready () {
   require('./lib/user-config')
 
   ipc.on('save-file', function () {
+    var ext = presets.metadata ? presets.metadata.dataset_id : 'mapeodata'
     electron.dialog.showSaveDialog(win, {
       title: 'Crear nuevo base de datos para sincronizar',
       defaultPath: 'base-de-datos-mapeo.mapeodata',
       filters: [
-        { name: 'Mapeo Data', extensions: ['mapeodata'] },
+        { name: 'Mapeo Data', extensions: [ext] },
       ]
     }, onopen)
 
@@ -111,11 +113,12 @@ function ready () {
   })
 
   ipc.on('open-file', function () {
+    var ext = presets.metadata ? presets.metadata.dataset_id : 'mapeodata'
     electron.dialog.showOpenDialog(win, {
       title: 'Seleccionar base de datos para sincronizar',
       properties: [ 'openFile' ],
       filters: [
-        { name: 'Mapeo Data', extensions: ['mapeodata'] },
+        { name: 'Mapeo Data', extensions: [ext] },
       ]
     }, onopen)
 

--- a/browser/main.js
+++ b/browser/main.js
@@ -72,7 +72,6 @@ function updateSettings () {
   var customCss = ipc.sendSync('get-user-data', 'css')
   var imagery = ipc.sendSync('get-user-data', 'imagery')
   var translations = ipc.sendSync('get-user-data', 'translations')
-  var metadata = ipc.sendSync('get-user-data', 'metadata')
   var icons = ipc.sendSync('get-user-data', 'icons')
   if (icons) {
     var iconsSvg = parser.parseFromString(icons, 'image/svg+xml').documentElement

--- a/lib/user-config.js
+++ b/lib/user-config.js
@@ -57,8 +57,16 @@ function getSettings (type) {
     case 'presets':
     case 'translations':
     case 'imagery':
-    case 'metadata':
       return readJsonSync(path.join(userDataPath, type + '.json'))
+    case 'metadata':
+      var data = readJsonSync(path.join(userDataPath, type + '.json'))
+      if (!data) {
+        return {
+          dataset_id: 'default'
+        }
+      } else {
+        return data
+      }
     default:
       return null
   }

--- a/server.js
+++ b/server.js
@@ -1,9 +1,5 @@
-var path = require('path')
-var ecstatic = require('ecstatic')
 var osmserver = require('osm-p2p-server')
 var http = require('http')
-var hyperlog = require('hyperlog')
-var level = require('level')
 var sneakernet = require('hyperlog-sneakernet-replicator')
 
 var body = require('body/any')
@@ -12,14 +8,10 @@ var exportGeoJson = require('osm-p2p-geojson')
 var importGeo = require('./lib/import-geo.js')
 var pump = require('pump')
 var shp = require('shpjs')
-var tmpdir = require('os').tmpdir()
 var concat = require('concat-stream')
 var wsock = require('websocket-stream')
 var eos = require('end-of-stream')
 var randombytes = require('randombytes')
-
-var userConfig = require('./lib/user-config')
-var metadata = userConfig.getSettings('metadata')
 
 module.exports = function (osm) {
   var osmrouter = osmserver(osm)
@@ -37,12 +29,14 @@ module.exports = function (osm) {
       })
     } else if (req.url.split('?')[0] === '/export.geojson') {
       var params = qs.parse(req.url.replace(/^[^\?]*?/, ''))
-      var bbox = [[params.minlat,params.maxlat],[params.minlon,params.maxlon]]
-        .map(function (pt) {
-          if (pt[0] === undefined) pt[0] = -Infinity
-          if (pt[1] === undefined) pt[1] = Infinity
-          return pt
-        })
+      var bbox = [
+        [params.minlat, params.maxlat],
+        [params.minlon, params.maxlon]
+      ].map(function (pt) {
+        if (pt[0] === undefined) pt[0] = -Infinity
+        if (pt[1] === undefined) pt[1] = Infinity
+        return pt
+      })
       res.setHeader('content-type', 'text/json')
       pump(exportGeoJson(osm, {bbox: bbox}), res)
     } else if (req.url === '/import.shp' && /^(PUT|POST)/.test(req.method)) {
@@ -52,14 +46,15 @@ module.exports = function (osm) {
           if (!(geojsons instanceof Array)) {
             geojsons = [geojsons]
           }
-          var errors = [], pending = 1
+          var errors = []
+          var pending = 1
           geojsons.forEach(function (geo) {
             importGeo(osm, geo, function (err) {
               if (err) errors.push(String(err.message || err))
               if (--pending === 0) done()
             })
           })
-          if (--pending === 0) done()
+          if (--pending === 0) { done() }
           function done () {
             res.end(JSON.stringify({
               errors: errors

--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@ var shp = require('shpjs')
 var tmpdir = require('os').tmpdir()
 var concat = require('concat-stream')
 var wsock = require('websocket-stream')
-var onend = require('end-of-stream')
+var eos = require('end-of-stream')
 var randombytes = require('randombytes')
 
 var userConfig = require('./lib/user-config')
@@ -74,15 +74,14 @@ module.exports = function (osm) {
   wsock.createServer({ server: server }, function (stream) {
     var id = randombytes(8).toString('hex')
     streams[id] = stream
-    onend(stream, function () { delete streams[id] })
+    eos(stream, function () { delete streams[id] })
   })
   return server
 
   function replicate (sourceFile) {
-
     console.log('replicating to', sourceFile)
-
     sneakernet(osm.log, { safetyFile: true }, sourceFile, onend)
+    replicating = true
 
     function onend (err) {
       if (err) return syncErr(err)


### PR DESCRIPTION
This adds a new configuration file, 'metadata.json' to the repo home directory. It contains a "dataset_id" field that gets bundled into the application's "presets" at build time.

This dataset identifier is then used in the application to name USB media sync files: a dataset_id of "foobar" results in sync files names "sync.foobar". This lets the open and save Electron dialogs filter out different datasets from human error.

Depends on https://github.com/digidem/mapeo-desktop/pull/49.