### PR TITLE
Electron logging

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -1,0 +1,94 @@
+var path = require('path')
+var fs = require('fs')
+var Console = require('console')
+var mkdir = require('mkdirp')
+var wsock = require('websocket-stream')
+var http = require('http')
+var through = require('through2')
+
+var nodeLogger = null
+var browserLogger = null
+
+var PORT = 17509
+
+module.exports.Node = function () {
+  if (!nodeLogger) {
+    nodeLogger = setupNodeLogger()
+  }
+  return nodeLogger
+}
+
+module.exports.Browser = function () {
+  if (!browserLogger) {
+    browserLogger = setupBrowserLogger()
+  }
+  return browserLogger
+}
+
+function setupNodeLogger () {
+  var electron = require('electron')
+
+  // create log dir
+  var logDir = path.join(electron.app.getPath('userData'), 'data', 'logs')
+  mkdir.sync(logDir)
+
+  // get electron app data dir
+  var filename = (new Date()).toISOString() + '.txt'
+  var logFilename = path.join(logDir, filename)
+
+  // fs write stream to file
+  var dest = fs.createWriteStream(logFilename)
+
+  // through stream to multiplex to stdout
+  var multi = multiplex([process.stdout, dest])
+
+  // create console instance
+  var log = new Console.Console(multi, null).log
+
+  // start ws server
+  websocketServer(function (socket) {
+    socket.on('data', function (text) {
+      multi.write(text)
+    })
+  })
+
+  return log
+}
+
+function setupBrowserLogger () {
+  var socket = wsock('ws://localhost:'+PORT)
+
+  var browserConsole = window.console
+
+  var stdout = through(function (chunk, enc, next) {
+    browserConsole.log(chunk.toString())
+    next()
+  })
+
+  // through stream to multiplex to stdout
+  var multi = multiplex([stdout, socket])
+
+  var c = new Console.Console(multi, null)
+
+  // capture browser errors
+  window.onerror = function (event, source, line, col) {
+    c.log(event, '(' + source + ':' + line + ':' +  col + ')')
+  }
+
+  return c.log
+}
+
+function websocketServer (handler, done) {
+  var server = http.createServer()
+  var ws = wsock.createServer({ server: server }, handler)
+  server.listen(PORT)
+}
+
+function multiplex (froms) {
+  return through(function (chunk, enc, next) {
+    for (var i = 0; i < froms.length; i++) {
+      froms[i].write(chunk.toString())
+    }
+    next()
+  })
+}

--- a/lib/log.js
+++ b/lib/log.js
@@ -81,13 +81,21 @@ function setupBrowserLogger () {
 function websocketServer (handler, done) {
   var server = http.createServer()
   var ws = wsock.createServer({ server: server }, handler)
-  server.listen(PORT)
+  console.log('ws prepped')
+  setTimeout(function () {
+    console.log('ws listening')
+    server.listen(PORT)
+  }, 25000)
 }
 
 function multiplex (froms) {
   return through(function (chunk, enc, next) {
     for (var i = 0; i < froms.length; i++) {
-      froms[i].write(chunk.toString())
+      try {
+        froms[i].write(chunk.toString())
+      } catch (e) {
+        // TODO: catch this inside setupBrowserLogger and trigger some reconnect logic
+      }
     }
     next()
   })

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "levelup": "^1.3.1",
     "lodash": "^4.15.0",
     "minimist": "^1.2.0",
+    "mkdirp": "^0.5.1",
     "once": "^1.3.3",
     "osm-p2p": "^1.4.0",
     "osm-p2p-geojson": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "electron-packager": "^7.6.0",
     "fs-extra": "^0.30.0",
     "iD": "openstreetmap/iD#v1.9.6",
-    "mkdirp": "^0.5.1",
     "npm-platform-dependencies": "0.0.12",
     "rimraf": "^2.5.2",
     "watchify": "^3.7.0"


### PR DESCRIPTION
This adds a small logging module to mapeo-desktop. It provides the following:

1. Both: A consistent `Console`-compatible interface for use in the node and
browser processes.
2. Node: logs to a text file in the user's electron application directory with
a unqiue timestamped filename.
2. Node: writes to both stdout and the log file.
3. Node: runs a tiny websocket server for browser communication.
4. Browser: connects to the node process' websocket server. (I could've used
ipc, but this will work across many windows without configuration.)
5. Browser: writes to both the websocket server and the browser's equivalent of
stdout.
6. Browser: captures browser errors and logs them.

All that's left is for us to start using the logging module in the codebase. Use is as simple as

```js
// node
var log = require('./lib/log').Node()
log('hello')

// browser
var log = require('./lib/log').Browser()
log('world')
```