### PR TITLE
Custom menu items

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ var TileImporter = require('./src/lib/tile-importer')
 var importer = require('./src/lib/importer')
 var locale = require('./src/lib/locale')
 var i18n = require('./src/lib/i18n')
+var exportData = require('./src/lib/export-data')
 
 if (require('electron-squirrel-startup')) {
   process.exit(0)
@@ -297,6 +298,10 @@ function createMainWindow (done) {
           win.webContents.send('select-file', file)
         }
       }
+    })
+
+    ipc.on('export-data', function (_, name, ext) {
+      exportData.openDialog(app, name, ext)
     })
 
     ipc.on('zoom-to-data-get-centroid', function () {

--- a/locales/en.json
+++ b/locales/en.json
@@ -16,7 +16,7 @@
   "menu-import-configuration-title": "Select configuration file",
   "menu-import-configuration-error": "Could not import configuration",
   "menu-import-configuration-error-known": "Could not import configuration because of an error",
-  "menu-export-data": "Export as...",
+  "menu-export-data": "Export",
   "menu-export-sync": "Mapeo Sync (.mapeodata)",
   "menu-export-geojson": "GeoJSON (.geojson)",
   "menu-export-shapefile": "Shapefile (.shp, .dbf)",

--- a/locales/es.json
+++ b/locales/es.json
@@ -17,7 +17,7 @@
   "menu-import-configuration-error": "No pudo importar configuración",
   "menu-import-configuration-error-known": "No pudo importar configuración por un error",
   "menu-export-sync": "Mapeo Sync (.mapeodata)",
-  "menu-export-data": "Exportar como...",
+  "menu-export-data": "Exportar",
   "menu-export-geojson": "GeoJSON (.geojson)",
   "menu-export-shapefile": "Shapefile (.shp, .dbf)",
   "menu-export-data-dialog": "Guardar como..",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.55",
     "@material-ui/core": "^1.5.1",
-    "@material-ui/icons": "^2.0.3",
+    "@material-ui/icons": "^3.0.0",
     "JSONStream": "^1.3.4",
     "application-config": "^1.0.1",
     "application-config-path": "^0.1.0",
@@ -100,7 +100,7 @@
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
     "react-intl": "^2.4.0",
-    "react-mapfilter": "^1.2.0",
+    "react-mapfilter": "^1.2.2",
     "rimraf": "^2.5.2",
     "run-series": "^1.1.4",
     "safe-fs-blob-store": "^1.0.0",

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { ipcRenderer } from 'electron'
 
+import SyncView from './SyncView'
 import LatLonDialog from './LatLonDialog'
 import MapEditor from './MapEditor'
 import MapFilter from './MapFilter'
@@ -17,19 +18,9 @@ export default class Home extends React.Component {
     self.state = {
       Modal: false,
       View: {
-        component: getView(lastView),
+        name: lastView,
+        component: self.getView(lastView),
         props: {}
-      }
-    }
-    function getView (view) {
-      if (!view) return Welcome
-      switch (view) {
-        case 'MapEditor':
-          return MapEditor
-        case 'MapFilter':
-          return MapFilter
-        default:
-          return MapFilter
       }
     }
     var prevhash = localStorage.getItem('location')
@@ -41,12 +32,30 @@ export default class Home extends React.Component {
     })
 
     ipcRenderer.on('open-latlon-dialog', function () {
-      self.openModal(LatLonDialog)
+      self.openModal('LatLonDialog')
     })
   }
 
-  changeView (component, state) {
-    var newState = Object.assign({}, { View: { component } }, state)
+  getView (name) {
+    if (!name) return Welcome
+    switch (name) {
+      case 'MapEditor':
+        return MapEditor
+      case 'MapFilter':
+        return MapFilter
+      case 'SyncView':
+        return SyncView
+      case 'LatLonDialog':
+        return LatLonDialog
+      default:
+        return MapFilter
+    }
+  }
+
+  changeView (name, state) {
+    var component = this.getView(name)
+    var View = { name, component }
+    var newState = Object.assign({}, { View }, state)
     this.setState(newState)
   }
 
@@ -54,14 +63,15 @@ export default class Home extends React.Component {
     this.setState({ Modal: false })
   }
 
-  openModal (component, props) {
+  openModal (name, props) {
     if (!props) props = {}
-    this.setState({ Modal: { component, props } })
+    var component = this.getView(name)
+    this.setState({ Modal: { name, component, props } })
   }
 
   render () {
     const { View, Modal } = this.state
-    localStorage.setItem('lastView', View.component.name)
+    localStorage.setItem('lastView', View.name)
 
     return (
       <div className='full'>

--- a/src/components/MapFilter.js
+++ b/src/components/MapFilter.js
@@ -9,8 +9,9 @@ import differenceBy from 'lodash/differenceBy'
 import url from 'url'
 
 import api from '../api'
+import MenuItems from './MenuItems'
 
-import Sidebar from './Sidebar'
+import MenuItem from '@material-ui/core/MenuItem'
 import ConvertDialog from './ConvertDialog'
 import randomBytes from 'randombytes'
 
@@ -170,9 +171,25 @@ class Home extends React.Component {
     this.setState({ mapPosition })
   }
 
+  onMenuItemClick (view) {
+    if (view.modal) this.props.openModal(view.name)
+    else this.props.changeView(view.name)
+  }
+
   render () {
     const { features, showModal, mapPosition } = this.state
-    const { changeView, openModal } = this.props
+
+    var appBarMenuItems = []
+
+    MenuItems.forEach((view, i) => {
+      if (view.name === 'MapFilter') return
+      appBarMenuItems.push(
+        <MenuItem
+          onClick={this.onMenuItemClick.bind(this, view)}>
+          {view.label}
+        </MenuItem>
+      )
+    })
 
     return (<div>
       <MapFilter
@@ -186,10 +203,7 @@ class Home extends React.Component {
         }}
         datasetName='mapeo'
         resizer={resizer}
-        appBarButtons={[<Sidebar
-          changeView={changeView}
-          openModal={openModal}
-        />]}
+        appBarMenuItems={appBarMenuItems}
         appBarTitle='Mapeo' />
 
       <ConvertDialog

--- a/src/components/MapFilter.js
+++ b/src/components/MapFilter.js
@@ -8,12 +8,22 @@ import xor from 'lodash/xor'
 import differenceBy from 'lodash/differenceBy'
 import url from 'url'
 
+import MenuItem from '@material-ui/core/MenuItem'
+import randomBytes from 'randombytes'
+
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles'
+
 import api from '../api'
 import MenuItems from './MenuItems'
-
-import MenuItem from '@material-ui/core/MenuItem'
 import ConvertDialog from './ConvertDialog'
-import randomBytes from 'randombytes'
+
+const theme = createMuiTheme({
+  palette: {
+    primary: {
+      main: '#39527b'
+    }
+  }
+})
 
 const osmServerHost = 'http://' + remote.getGlobal('osmServerHost')
 
@@ -192,24 +202,26 @@ class Home extends React.Component {
     })
 
     return (<div>
-      <MapFilter
-        mapStyle={styleUrl}
-        features={features}
-        mapPosition={mapPosition}
-        onChangeMapPosition={this.handleChangeMapPosition.bind(this)}
-        onChangeFeatures={this.handleChangeFeatures}
-        fieldTypes={{
-          notes: FIELD_TYPE_STRING
-        }}
-        datasetName='mapeo'
-        resizer={resizer}
-        appBarMenuItems={appBarMenuItems}
-        appBarTitle='Mapeo' />
+      <MuiThemeProvider theme={theme}>
+        <MapFilter
+          mapStyle={styleUrl}
+          features={features}
+          mapPosition={mapPosition}
+          onChangeMapPosition={this.handleChangeMapPosition.bind(this)}
+          onChangeFeatures={this.handleChangeFeatures}
+          fieldTypes={{
+            notes: FIELD_TYPE_STRING
+          }}
+          datasetName='mapeo'
+          resizer={resizer}
+          appBarMenuItems={appBarMenuItems}
+          appBarTitle='Mapeo' />
 
-      <ConvertDialog
-        open={showModal === 'convert'}
-        onClose={() => { this.setState({ showModal: false }) }}
-        features={features} />
+        <ConvertDialog
+          open={showModal === 'convert'}
+          onClose={() => { this.setState({ showModal: false }) }}
+          features={features} />
+      </MuiThemeProvider>
 
     </div>)
   }

--- a/src/components/MenuItems.js
+++ b/src/components/MenuItems.js
@@ -1,0 +1,17 @@
+const MenuItems = [
+  {
+    name: 'MapEditor',
+    label: 'Map Editor'
+  },
+  {
+    name: 'MapFilter',
+    label: 'Map Filter'
+  },
+  {
+    name: 'SyncView',
+    label: 'Sync with...',
+    modal: true
+  }
+]
+
+export default MenuItems

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,69 +1,25 @@
 import React from 'react'
-import styled from 'styled-components'
 import { ipcRenderer, shell } from 'electron'
+import styled from 'styled-components'
 
+import MoreVertIcon from '@material-ui/icons/MoreVert'
+import i18n from '../lib/i18n'
 import ImportProgressBar from './ImportProgressBar'
 import IndexesBar from './IndexesBar'
-import MapEditor from './MapEditor'
-import MapFilter from './MapFilter'
-import SyncView from './SyncView'
+import MenuItems from './MenuItems'
 
-var SidebarItem = styled.div`
-  font-size: 14px;
-  padding: 5px 20px;
-  color: black;
-  &:hover {
-    background-color: var(--button-hover-bg-color);
-    color: var(--button-hover-color);
-    cursor: pointer;
-  }
-`
+import MenuItem from '@material-ui/core/MenuItem'
+import Menu from '@material-ui/core/Menu'
+import IconButton from '@material-ui/core/IconButton'
 
-var MenuButton = styled.div`
-  font-size: 14px;
-  max-height: 60px;
-  line-height: 40px;
-  text-align: center;
-  font-weight: bold;
-  z-index: var(--visible-z-index);
-  color: black;
-  background-color: white;
-  border-radius: 5px;
-  min-width: 100px;
-  &:hover {
-    background-color: #ececec;
-    color: black;
-    cursor: pointer;
-  }
-  .notification {
-    background-color: var(--main-bg-color);
-    border-radius: 50%;
-    width: 15px;
-    height: 15px;
-    line-height: 15px;
-    color: white;
-    font-size: 10px;
-    position: absolute;
-    margin-left: 5px;
-    top: 5px;
-    right: 15px;
-  }
-`
-
-var SidebarDiv = styled.div`
-  z-index: var(--visible-z-index);
-  position: absolute;
-  padding: 10px 0px;
-  text-align: right;
-  border-radius: 5px;
-  background-color: white;
-  color: black;
-  max-width: 200px;
-  right: 50px;
-  top: 50px;
-  display: none;
-  &.open {
-    display: block;
+var FixedTopMenu = styled.div`
+  top: 0;
+  right: 0;
+  position: fixed;
+  z-index: 30;
+  padding: 5px;
+  button {
+    background-color: white;
   }
 `
 
@@ -71,9 +27,10 @@ export default class Sidebar extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
-      sidebar: false,
+      anchorEl: null,
       notifications: 0
     }
+    this.handleClose = this.handleClose.bind(this)
   }
 
   removeNotification () {
@@ -81,6 +38,7 @@ export default class Sidebar extends React.Component {
       notifications: Math.max(this.state.notifications - 1, 0)
     })
   }
+
   addNotification () {
     this.setState({
       notifications: this.state.notifications + 1
@@ -93,14 +51,18 @@ export default class Sidebar extends React.Component {
   }
 
   onSidebarClick (view) {
-    if (view.modal) this.props.openModal(view.component)
-    else this.props.changeView(view.component)
-    this.setState({ sidebar: false })
+    if (view.modal) this.props.openModal(view.name)
+    else this.props.changeView(view.name)
+    this.handleClose()
   }
 
-  toggleSidebar () {
+  handleClose () {
+    this.setState({ anchorEl: null })
+  }
+
+  toggleSidebar (event) {
     this.setState({
-      sidebar: !this.state.sidebar,
+      anchorEl: event.currentTarget,
       notifications: 0
     })
   }
@@ -110,47 +72,46 @@ export default class Sidebar extends React.Component {
   }
 
   render () {
-    const { notifications, sidebar } = this.state
+    const { notifications, anchorEl } = this.state
 
-    var views = [
-      {
-        component: MapEditor,
-        label: 'Map Editor'
-      },
-      {
-        component: MapFilter,
-        label: 'Map Filter'
-      },
-      {
-        component: SyncView,
-        label: 'Sync with...',
-        modal: true
-      }
-    ]
-
-    return (<div>
-      <MenuButton className='menu' onClick={this.toggleSidebar.bind(this)}>
-        Menu {notifications > 0 && <div className='notification'>{notifications}</div>}
-      </MenuButton>
-
-      {<SidebarDiv className={sidebar ? 'open' : ''}>
+    return (<FixedTopMenu>
+      <IconButton
+        aria-owns={anchorEl ? 'simple-menu' : null}
+        aria-haspopup='true'
+        onClick={this.toggleSidebar.bind(this)}>
+        <MoreVertIcon />
+      </IconButton>
+      <Menu id='the-menu' anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={this.handleClose}>
         <ImportProgressBar />
         <IndexesBar />
-        {views.map((view, i) => {
+        <ExportSidebarItem name='GeoJSON' ext='geojson' />
+        <ExportSidebarItem name='ShapeFile' ext='shp' />
+        {MenuItems.map((view, i) => {
           var id = `menu-option-${i}`
+          if (view.name === 'MapEditor') return
           return (
-            <SidebarItem
+            <MenuItem
               id={id}
               key={i}
               onClick={this.onSidebarClick.bind(this, view)}>
               {view.label}
-            </SidebarItem>)
+            </MenuItem>)
         })}
-      </SidebarDiv>
-
-      }
-    </div>
+      </Menu>
+    </FixedTopMenu>
     )
+  }
+}
+
+class ExportSidebarItem extends React.Component {
+  render () {
+    const { name, ext } = this.props
+
+    function onClick () {
+      ipcRenderer.send('export-data', name, ext)
+    }
+    var label = `${i18n('menu-export-data')} ${name}...`
+    return <MenuItem onClick={onClick}>{label}</MenuItem>
   }
 }
 
@@ -159,3 +120,4 @@ export default class Sidebar extends React.Component {
 //     Report Issue
 //   </SidebarItem>
 // </SidebarFooter>
+

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -72,7 +72,7 @@ export default class Sidebar extends React.Component {
   }
 
   render () {
-    const { notifications, anchorEl } = this.state
+    const { anchorEl } = this.state
 
     return (<FixedTopMenu>
       <IconButton
@@ -120,4 +120,3 @@ class ExportSidebarItem extends React.Component {
 //     Report Issue
 //   </SidebarItem>
 // </SidebarFooter>
-

--- a/src/components/SyncView.js
+++ b/src/components/SyncView.js
@@ -7,7 +7,6 @@ import DoneIcon from '@material-ui/icons/Done'
 import ErrorIcon from '@material-ui/icons/Error'
 
 import api from '../api'
-import MapFilter from './MapFilter'
 import Modal from './Modal'
 import Form from './Form'
 import i18n from '../lib/i18n'
@@ -123,7 +122,7 @@ export default class SyncView extends React.Component {
 
   onClose () {
     this.props.onClose()
-    if (this.state.replicated) this.props.changeView(MapFilter)
+    if (this.state.replicated) this.props.changeView('MapFilter')
     ipcRenderer.send('refresh-window')
   }
 

--- a/src/components/Welcome.js
+++ b/src/components/Welcome.js
@@ -3,8 +3,6 @@ import { ipcRenderer } from 'electron'
 import React from 'react'
 
 import _i18n from '../lib/i18n'
-import MapEditor from './MapEditor'
-import SyncView from './SyncView'
 import View from './View'
 
 function i18n (id) {
@@ -26,16 +24,16 @@ export default class Welcome extends React.Component {
 
   presetsButton () {
     ipcRenderer.send('import-example-presets')
-    this.props.changeView(MapEditor)
+    this.props.changeView('MapEditor')
   }
 
   examplesButton () {
     var filename = ipcRenderer.sendSync('get-example-filename')
-    this.props.changeView(MapEditor, { Modal: { component: SyncView, props: { filename } } })
+    this.props.changeView('MapEditor', { Modal: { name: 'SyncView', props: { filename } } })
   }
 
   openMap () {
-    this.props.changeView(MapEditor)
+    this.props.changeView('MapEditor')
   }
 
   render () {

--- a/src/lib/export-data.js
+++ b/src/lib/export-data.js
@@ -1,10 +1,35 @@
+var dialog = require('electron').dialog
 var path = require('path')
 var pump = require('pump')
 var fs = require('fs')
+
 var exportGeoJson = require('./export-geojson')
 var exportShapefile = require('./export-shapefile')
+var i18n = require('./i18n')
 
-module.exports = function (mapeo, filename, done) {
+module.exports = {
+  exportData,
+  openDialog
+}
+
+function openDialog (app, name, ext) {
+  dialog.showSaveDialog({
+    title: i18n('menu-export-data-dialog'),
+    defaultPath: `export.${ext}`,
+    filters: [{ name: name, extensions: [ext] }]
+  }, function (filename) {
+    if (!filename) return
+    exportData(app.server.mapeo, filename, function (err) {
+      if (err) dialog.showErrorBox('Error', i18n('menu-export-data-error') + err)
+      dialog.showMessageBox({
+        message: i18n('menu-export-data-success'),
+        buttons: ['OK']
+      })
+    })
+  })
+}
+
+function exportData (mapeo, filename, done) {
   var ext = path.extname(filename)
   switch (ext) {
     case '.geojson': return pump(exportGeoJson(mapeo.api.osm), fs.createWriteStream(filename), done)

--- a/src/menu.js
+++ b/src/menu.js
@@ -292,19 +292,6 @@ module.exports = function (app) {
 
 function exportDataMenu (app, name, ext) {
   return function (item, focusedWindow) {
-    dialog.showSaveDialog({
-      title: i18n('menu-export-data-dialog'),
-      defaultPath: `export.${ext}`,
-      filters: [{ name: name, extensions: [ext] }]
-    }, function (filename) {
-      if (!filename) return
-      exportData(app.server.mapeo, filename, function (err) {
-        if (err) dialog.showErrorBox('Error', i18n('menu-export-data-error') + err)
-        dialog.showMessageBox({
-          message: i18n('menu-export-data-success'),
-          buttons: ['OK']
-        })
-      })
-    })
+    exportData.openDialog(app, name, ext)
   }
 }

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -61,6 +61,10 @@ button.big:hover:not([disabled]) {
   background-color: var(--button-hover-bg-color);
 }
 
+#bar {
+  background-color: var(--main-bg-color);
+}
+
 #logoutLink,
 #userLink,
 .save-communityLinks,


### PR DESCRIPTION
depends upon https://github.com/digidem/react-mapfilter/pull/94

tiny TODOs left:
- [x] use material-ui component for mapeditor menu
- [x] internationalize 'export' in mapeditor menu
- [x] only display mapfilter when in map editor, and vice versa (rather than displaying both as options in both views)
- [x] ellipses ... in mapeditor

This makes the menus a bit easier to understand and more symmetrical in both map editor and mapfilter mode.

MapEditor now has two export options in the menu (`geojson` and `shapefile`) while in mapfilter mode we have `csv` and `geojson`.
![screenshot from 2018-09-25 18-48-24](https://user-images.githubusercontent.com/633012/46052505-9ee20a80-c0f3-11e8-9ef1-5881edcf30dc.png)

Now, there's only one Mapfilter menu instead of two and it has the ability to sync and see the MapEditor screen
![screenshot from 2018-09-25 18-48-16](https://user-images.githubusercontent.com/633012/46052514-a99c9f80-c0f3-11e8-99be-5b5e7fa1ab5d.png)

