### PR TITLE
Added logo to browser window

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,7 +217,11 @@ function createMainWindow (done) {
 
     var INDEX = 'file://' + path.resolve(__dirname, './index.html')
     if (!win) {
-      win = new BrowserWindow({ title: APP_NAME, show: false })
+      win = new BrowserWindow({
+        title: APP_NAME,
+        show: false,
+        icon: path.resolve(__dirname, 'static', 'mapeo_256x256.png')
+      })
       win.once('ready-to-show', () => win.show())
       if (IS_TEST) win.setSize(1000, 800, false)
       else win.maximize()


### PR DESCRIPTION
This PR proposes adding a logo to the [`BrowserWindow`](https://electronjs.org/docs/api/browser-window#new-browserwindowoptions). I am not sure about Win/Mac platform, but at least on Linux platforms there will be a nice logo showing in the taskbar.

Before:
![](https://user-images.githubusercontent.com/284779/46663798-8fac9380-cbae-11e8-8ed2-c13b2e62254a.png)
After:
![](https://user-images.githubusercontent.com/284779/46663797-8f13fd00-cbae-11e8-82d3-9c614faffc7f.png)