### PR TITLE
Prevent double sync

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -5,6 +5,7 @@ import querystring from 'querystring'
 const osmServerHost = 'http://' + remote.getGlobal('osmServerHost')
 
 module.exports = {
+  stop,
   unannounce,
   announce,
   getTargets,
@@ -51,6 +52,17 @@ function getTargets (cb) {
     } catch (err) {
       return cb(err)
     }
+  })
+}
+
+function stop (target, cb) {
+  var opts = {
+    method: 'GET',
+    url: `${osmServerHost}/sync/stop`
+  }
+  xhr(opts, function (err, res, body) {
+    if (err) return cb(err)
+    cb(null, body)
   })
 }
 

--- a/src/components/SyncView.js
+++ b/src/components/SyncView.js
@@ -84,7 +84,8 @@ export default class SyncView extends React.Component {
     super(props)
     this.state = {
       targets: [],
-      replicated: false
+      replicated: false,
+      syncing: false
     }
     this.selectFile = this.selectFile.bind(this)
   }
@@ -92,6 +93,7 @@ export default class SyncView extends React.Component {
   replicate (target) {
     var self = this
     if (!target) return
+    self.setState({ syncing: true })
     api.start(target, function (err, body) {
       if (err) console.error(err) // TODO handle errors more gracefully
       self.setState({ replicated: true })
@@ -142,7 +144,7 @@ export default class SyncView extends React.Component {
 
   render () {
     var self = this
-    var { targets } = this.state
+    var { syncing, targets } = this.state
     if (this.props.filename) this.replicate({ filename: this.props.filename })
     var onClose = this.onClose.bind(this)
 
@@ -166,24 +168,34 @@ export default class SyncView extends React.Component {
             )
           })}
         </TargetsDiv>
-        <Form method='POST'>
-          <input type='hidden' name='source' />
-          <div className='button-group'>
-            <Button onClick={this.selectExisting}>
-              <span id='button-text'>
-                {i18n('sync-database-open-button')}&hellip;
-              </span>
-            </Button>
-            <Button onClick={this.selectNew}>
-              <span id='button-text'>
-                {i18n('sync-database-new-button')}&hellip;
-              </span>
-            </Button>
-            <Button id='sync-done' onClick={onClose}>
-              {i18n('done')}
-            </Button>
-          </div>
-        </Form>
+        { syncing ?
+          <Form method='POST'>
+            <input type='hidden' name='source' />
+            <div className='button-group'>
+              <Button onClick={this.selectExisting}>
+                <span id='button-text'>
+                  {i18n('sync-database-open-button')}&hellip;
+                </span>
+              </Button>
+              <Button onClick={this.selectNew}>
+                <span id='button-text'>
+                  {i18n('sync-database-new-button')}&hellip;
+                </span>
+              </Button>
+              <Button id='sync-done' onClick={onClose}>
+                {i18n('done')}
+              </Button>
+            </div>
+          </Form>
+          :
+          <Form method='POST'>
+            <div className='button-group'>
+              <Button id='sync-done' onClick={onClose}>
+                {i18n('cancel')}
+              </Button>
+            </div>
+          </Form>
+        }
       </Modal>
     )
   }

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -20,9 +20,19 @@ body {
   overflow: hidden;
 }
 
-.button-group {
+.modal-padding {
   padding: 10px;
+  background-color: --main-bg-color;
 }
+
+.modal-full-size button {
+  /* cause material-ui hates me. REFACTOR */
+  padding: 0px !important;
+  margin: 0px;
+  margin-left: 0px !important;
+  width: 100%;
+}
+
 .right {
   text-align: right;
 }


### PR DESCRIPTION
This PR brings us one step closer to @aldopuicon 's ideal sync interaction.

* While sync is in progress, there are no buttons. 
* A sync that is currently in progress cannot be cancelled, yet. I wrote in capability to 'stop' the target in the server api, but the UI doesn't expose it yet. I figured this was a new feature and should be integrated on a feature branch separate from this one.
* Only one target is displayed while sync is in progress or complete. If you want to sync again, you need to hit 'ok' and re-open the sync screen.

![mapfilter-sync-discovery-failed](https://user-images.githubusercontent.com/633012/46878025-05a33b80-cdf7-11e8-9737-7f3d7da0a0eb.png)

![screenshot from 2018-10-12 08-16-59](https://user-images.githubusercontent.com/633012/46878097-3e431500-cdf7-11e8-85d4-1ad9c086e1f6.png)

![mapfilter-sync-complete-2](https://user-images.githubusercontent.com/633012/46878011-fd4b0080-cdf6-11e8-860d-255a53e09e0e.png)