### PR TITLE
feat(zoom-to-data): use a low-rez node density tilemap

### DIFF
--- a/index.js
+++ b/index.js
@@ -306,6 +306,7 @@ function createMainWindow (done) {
 
     ipc.on('zoom-to-data-get-centroid', function () {
       getGlobalDatasetCentroid(function (_, loc) {
+        if (!loc) return
         win.webContents.send('zoom-to-data-response', loc)
       })
     })
@@ -324,6 +325,7 @@ function createMainWindow (done) {
     win.webContents.once('did-finish-load', function () {
       win.webContents.send('indexes-loading')
       app.osm.ready(function () {
+        log('indexes READY')
         win.webContents.send('indexes-ready')
       })
     })
@@ -363,6 +365,7 @@ function handleUncaughtExceptions () {
 function getGlobalDatasetCentroid (done) {
   app.osm.stats.getMapCenter(function (err, center) {
     if (err) return log('ERROR(getGlobalDatasetCentroid):', err)
+    if (!center) return done(null, null)
     console.log('center', center)
     done(null, [center.lon, center.lat])
   })

--- a/src/lib/osm-stats.js
+++ b/src/lib/osm-stats.js
@@ -4,21 +4,21 @@ var sub = require('subleveldown')
 module.exports = installStatsIndex
 
 function installStatsIndex (osm) {
-  var idb = sub(osm.db, 'stat')
+  var idb = sub(osm.db, 'stat2')
   var idx = Index({
     log: osm.log,
     db: idb,
     map: function (row, next) {
       if (row.value.k && row.value.v && row.value.v.type === 'node') {
         var node = row.value.v
-        // console.log('indexing', row.key)
-        getIndexState(function (err, stats) {
-          if (err) return next(err)
-          stats.latSum += Number(node.lat)
-          stats.lonSum += Number(node.lon)
-          stats.numNodes++
-          // console.log('writing stats', stats)
-          writeIndexState(next)
+
+        // update density map
+        var binId = nodeToBinId(node)
+        idb.get('bin/' + binId, function (err, num) {
+          if (err && err.notFound) num = 0
+          else if (err) return done(err)
+          num = Number(num) + 1
+          idb.put('bin/' + binId, num, next)
         })
       } else {
         next()
@@ -26,56 +26,44 @@ function installStatsIndex (osm) {
     }
   })
 
-  var stats
-
   // install 'stats' property into osm object
   osm.stats = {
     getMapCenter: function (cb) {
       idx.ready(function () {
-        getIndexState(function (err, stats) {
-          if (err) return cb(err)
-          var center = {
-            lat: stats.latSum / stats.numNodes,
-            lon: stats.lonSum / stats.numNodes
+        var rs = idb.createReadStream({gt: 'bin/!', lt: 'bin/~'})
+        var mostDense = null
+        rs.on('data', function (entry) {
+          if (mostDense === null || Number(entry.value) > Number(mostDense.value)) {
+            mostDense = entry
           }
-          return cb(null, center)
         })
+        rs.once('end', function () {
+          if (!mostDense) return cb(null, null)
+          var center = binIdToLatLon(mostDense.key.substring(4))
+          cb(null, center)
+        })
+        rs.once('error', cb)
       })
     }
-  }
-
-  function writeIndexState (cb) {
-    var batch = [
-      { type: 'put', key: 'lat-sum', value: stats.latSum },
-      { type: 'put', key: 'lon-sum', value: stats.lonSum },
-      { type: 'put', key: 'num-nodes', value: stats.numNodes }
-    ]
-    // console.log('writing batch stats index', batch)
-    idb.batch(batch, cb)
-  }
-
-  function getIndexState (cb) {
-    if (stats) {
-      return process.nextTick(cb.bind(null, null, stats))
-    }
-
-    idb.get('lat-sum', function (err, latSum) {
-      if (err && !err.notFound) return cb(err)
-      if (err && err.notFound) latSum = 0
-      idb.get('lon-sum', function (err, lonSum) {
-        if (err && !err.notFound) return cb(err)
-        if (err && err.notFound) lonSum = 0
-        idb.get('num-nodes', function (err, numNodes) {
-          if (err && !err.notFound) return cb(err)
-          if (err && err.notFound) numNodes = 0
-          stats = {
-            latSum: Number(latSum),
-            lonSum: Number(lonSum),
-            numNodes: Number(numNodes)
-          }
-          cb(null, stats)
-        })
-      })
-    })
   }
 }
+
+function nodeToBinId (node) {
+  var lat = Number(node.lat)
+  var lon = Number(node.lon)
+  if (Number.isNaN(lat) || lat === undefined || lat === null) return null
+  if (Number.isNaN(lon) || lon === undefined || lon === null) return null
+  var latbin = Math.round(lat * 50) / 50
+  var lonbin = Math.round(lon * 50) / 50
+  return latbin + ',' + lonbin
+}
+
+function binIdToLatLon (binId) {
+  var lat = Number(binId.split(',')[0])
+  var lon = Number(binId.split(',')[1])
+  return {
+    lat: lat,
+    lon: lon
+  }
+}
+


### PR DESCRIPTION
Creates a new version of the "osm stats" index that builds a low resolution density map of all nodes. When zooming to data, the tile with the highest density is used.
