### PR TITLE
only append customDefs when it doesn't already exist

### DIFF
--- a/src/components/MapEditor.js
+++ b/src/components/MapEditor.js
@@ -80,15 +80,17 @@ export default class MapEditor extends React.Component {
       .minEditableZoom(14)
 
     this.id.version = pkg.version
-    this.customDefs = this.id.container()
-      .append('svg')
-      .style('position', 'absolute')
-      .style('width', '0px')
-      .style('height', '0px')
-      .attr('id', 'custom-defs')
-      .append('defs')
+    if (!this.customDefs) {
+      this.customDefs = this.id.container()
+        .append('svg')
+        .style('position', 'absolute')
+        .style('width', '0px')
+        .style('height', '0px')
+        .attr('id', 'custom-defs')
+        .append('defs')
 
-    this.customDefs.append('svg')
+      this.customDefs.append('svg')
+    }
 
     this.id.ui()(document.getElementById('container'), function onLoad () {
       var links = document.querySelectorAll('a[href^="http"]')


### PR DESCRIPTION
this wasn't really creating any issues, but will keep the DOM from stacking up unnecessary divs