### PR TITLE
HACK: refresh iD editor to fix bug where points would not appear

### DIFF
--- a/src/components/MapEditor.js
+++ b/src/components/MapEditor.js
@@ -125,6 +125,8 @@ export default class MapEditor extends React.Component {
       self.updateSettings()
     })
 
+    setTimeout(() => this.refreshWindow(), 1000)
+
     window.onbeforeunload = function () { self.id.save() }
   }
 

--- a/src/components/MapEditor.js
+++ b/src/components/MapEditor.js
@@ -27,6 +27,7 @@ export default class MapEditor extends React.Component {
   constructor (props) {
     super(props)
     var self = this
+    this.iDContainer = React.createRef()
     this.refreshWindow = this.refreshWindow.bind(this)
     this.zoomToDataRequest = this.zoomToDataRequest.bind(this)
     this.zoomToDataResponse = this.zoomToDataResponse.bind(this)
@@ -59,7 +60,7 @@ export default class MapEditor extends React.Component {
             openModal={this.props.openModal}
           />
         </Overlay>
-        <div id='container' />
+        <div ref={this.iDContainer} />
       </div>
     )
   }
@@ -75,7 +76,6 @@ export default class MapEditor extends React.Component {
 
   componentDidMount () {
     var self = this
-    this.mounted = true
     this.updateSettings()
 
     var serverUrl = 'http://' + remote.getGlobal('osmServerHost')
@@ -85,6 +85,7 @@ export default class MapEditor extends React.Component {
       .minEditableZoom(14)
 
     this.id.version = pkg.version
+
     if (!this.customDefs) {
       this.customDefs = this.id.container()
         .append('svg')
@@ -97,7 +98,7 @@ export default class MapEditor extends React.Component {
       this.customDefs.append('svg')
     }
 
-    this.id.ui()(document.getElementById('container'), function onLoad () {
+    this.id.ui()(this.iDContainer.current, function onLoad () {
       var links = document.querySelectorAll('a[href^="http"]')
       links.forEach(function (link) {
         var href = link.getAttribute('href')
@@ -123,6 +124,7 @@ export default class MapEditor extends React.Component {
         latlon.text(s)
       })
       self.updateSettings()
+      setTimeout(() => self.id.flush(), 1500)
     })
 
     setTimeout(() => this.refreshWindow(), 1000)


### PR DESCRIPTION
Bug: in some cases points would not appear in MapEditor view

Reproduce:
1. Create some points in Map Editor (or alternatively, have some points ready)
2. Open Map Filter
3. Open Map Editor again. Points have disappeared.
4. Refresh/restart Mapeo. Points appear in Map Editor again.

Doing a window refresh in the code also seems to fix it, but it has to be after a certain period of time. See the timeout added. 

I spent an hour or so trying to figure out where in iD we could do this directly, instead of hacking it on top. I wouldn't recommend merging this pull request as it is a total hack, but it is better than people thinking they've lost their data entirely. I just haven't figured out a better way quite yet.

