### PR TITLE
Tiles asar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ change your URL from `/Offline-Maps/...` to `/styles/Offline-Maps/...`.
   `styles/default`, instead of `styles/mapfilter-style`. This will make feature
 parity between mobile and desktop.
 
+
+- Presets require a namespace now, which is `default`. If you don't see your
+  presets from a previous installation, you'll need to re-import the
+configuration file from **File->Import configuration**
+
 ### Bug Fixes
 
 - Map Filter should work much faster and more reliably now, a number of bug

--- a/README.md
+++ b/README.md
@@ -112,7 +112,23 @@ See [downloading tiles for offline use](docs/offline_tiles.md).
 
 # Custom Presets
 
-(coming soon)
+Presets must be placed in this folder:
+
+```txt
+%USERDATA%/Mapeo/presets/default
+```
+
+This folder (`default`) should contain these files directly in under this
+`default` folder (i.e. no sub-folder with a different name):
+
+```txt
+presets.json
+icons/
+  myIcon-medium@1x.png
+  myIcon-medium@2x.png
+  myIcon-medium@3x.png
+  ...etc
+```
 
 # License
 

--- a/docs/offline_tiles.md
+++ b/docs/offline_tiles.md
@@ -23,7 +23,7 @@ setting. You can modify the paramters based upon your setup.
 Mapeo runs its own maptile server in the background. The server for tile data that is imported from the `File->Import Offline Map  Tiles...` should be:
 
 ```
-http://localhost:5005/Offline-Maps/tiles/{zoom}/{x}/{y}
+http://localhost:5005/styles/default/tiles/{zoom}/{x}/{y}
 ```
 
 It will try to use `.jpg`, `.png`, and `.jpeg` extensions. It does not yet support `asar` or `.mbtiles` formats directly, [PRs welcome](https://github.com/digidem/mapeo-desktop/issues/103).

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ if (require('electron-squirrel-startup')) {
 // HACK: enable GPU graphics acceleration on some older laptops
 app.commandLine.appendSwitch('ignore-gpu-blacklist', 'true')
 
+process.noAsar = true
 // Set up global node exception handler
 handleUncaughtExceptions()
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -9,6 +9,8 @@
   "menu-file": "File",
   "menu-change-language": "Change language...",
   "menu-change-language-title": "Enter the language (e.g., 'en' or 'es')",
+  "menu-import-tiles-file": "File (.asar, .tar)",
+  "menu-import-tiles-directory": "Directory of tiles",
   "menu-import-tiles": "Import Offline Map Tiles...",
   "menu-import-tiles-error": "Could not import tiles",
   "menu-import-tiles-error-known": "Could not import tiles because of an error",

--- a/locales/es.json
+++ b/locales/es.json
@@ -9,6 +9,8 @@
   "menu-file": "Archivo",
   "menu-change-language": "Cambiar idioma...",
   "menu-change-language-title": "Ingrese el idioma (e.g., 'en' or 'es')",
+  "menu-import-tiles-file": "Archivo (.asar, .tar)",
+  "menu-import-tiles-directory": "Carpeta",
   "menu-import-tiles": "Importar Offline Map Tiles...",
   "menu-import-tiles-error": "No pudo importar archivo",
   "menu-import-tiles-error-known": "No pudo importar archivo por un error",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "JSONStream": "^1.3.5",
     "application-config": "^1.0.1",
     "application-config-path": "^0.1.0",
+    "asar": "^1.0.0",
     "blob-to-buffer": "^1.2.6",
     "body": "^5.1.0",
     "concat-stream": "^1.5.1",

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -3,8 +3,11 @@ var dialog = require('electron').dialog
 var userConfig = require('./user-config')
 var exportData = require('./export-data')
 var i18n = require('../i18n')
+var logger = require('../log')
+var log
 
 module.exports = function (app) {
+  log = logger.Node()
   var template = [
     {
       label: i18n('menu-file'),
@@ -12,19 +15,26 @@ module.exports = function (app) {
         {
           label: i18n('menu-import-tiles'),
           click: function (item, focusedWindow) {
-            dialog.showOpenDialog({
+            var opts = {
               title: i18n('menu-import-tiles'),
-              properties: ['openFile', 'openDirectory']
-            }, function (filenames) {
+              properties: ['openFile'],
+              filters: [
+                { name: 'Electron Asar', extensions: ['asar'] },
+                { name: 'Tar', extensions: ['tar'] }
+              ]
+            }
+            dialog.showOpenDialog(opts, function (filenames) {
               if (!filenames) return
               app.tiles.go(filenames[0], cb)
               function cb (err) {
                 if (err) {
+                  log('[IMPORT TILES] error', err)
                   dialog.showErrorBox(
                     i18n('menu-import-tiles-error'),
                     i18n('menu-import-tiles-error-known') + ': ' + err
                   )
                 } else {
+                  log('[IMPORT TILES] success')
                   dialog.showMessageBox({
                     message: i18n('menu-import-data-success'),
                     buttons: ['OK']

--- a/src/main/tile-server.js
+++ b/src/main/tile-server.js
@@ -4,7 +4,7 @@ var app = require('electron').app
 var path = require('path')
 var series = require('run-series')
 
-var tilePath = path.join(app.getPath('userData'), 'styles')
+var tilePath = path.join(app.getPath('userData'))
 
 module.exports = function () {
   var guesses = ['png', 'jpg', 'jpeg']

--- a/src/main/user-config.js
+++ b/src/main/user-config.js
@@ -1,11 +1,13 @@
 var fs = require('fs')
 var tar = require('tar-fs')
 var pump = require('pump')
+var mkdirp = require('mkdirp')
 var path = require('path')
 var app = require('electron').app
 var userDataPath = app.getPath('userData')
-var cssPath = path.join(userDataPath, 'style.css')
-var iconsPath = path.join(userDataPath, 'icons.svg')
+var defaultPath = path.join(userDataPath, 'presets', 'default')
+var cssPath = path.join(defaultPath, 'style.css')
+var iconsPath = path.join(defaultPath, 'icons.svg')
 
 var SETTINGS_FILES = [
   'presets.json',
@@ -38,7 +40,8 @@ function readFile (filepath) {
 
 function importSettings (win, settingsFile, cb) {
   var source = fs.createReadStream(settingsFile)
-  var dest = tar.extract(userDataPath, {
+  mkdirp.sync(defaultPath)
+  var dest = tar.extract(defaultPath, {
     ignore: function (name) {
       return SETTINGS_FILES.indexOf(path.basename(name)) < 0
     }
@@ -58,9 +61,9 @@ function getSettings (type) {
       return readFile(iconsPath)
     case 'presets':
     case 'imagery':
-      return readJsonSync(path.join(userDataPath, type + '.json'))
+      return readJsonSync(path.join(defaultPath, type + '.json'))
     case 'metadata':
-      var data = readJsonSync(path.join(userDataPath, type + '.json'))
+      var data = readJsonSync(path.join(defaultPath, type + '.json'))
       return Object.assign(METADATA_DEFAULTS, data)
     default:
       return null

--- a/src/renderer/components/MapFilter.js
+++ b/src/renderer/components/MapFilter.js
@@ -33,7 +33,7 @@ const DONT_UPDATE_PROPS = [
   'timestamp'
 ]
 
-const customStyleUrl = `${osmServerHost}/styles/mapfilter-style/style.json`
+const customStyleUrl = `${osmServerHost}/styles/default/style.json`
 const defaultStyleUrl = `${osmServerHost}/static/style.json`
 
 const fieldTypes = {


### PR DESCRIPTION
## Breaking Changes

* Map tiles and aerial imagery now must be referenced from under a `styles`  directory. If you were using background imagery in 3.x, you will need to change your URL from `/Offline-Maps/...` to `/styles/Offline-Maps/...`. 

* Presets require a namespace now, which is `default`. If you don't see your presets from a previous installation, you'll need to re-import the configuration file from **File->Import configuration**
