### PR TITLE
Correcting the invalid SPDX "license" expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "rebuild-leveldb": "cd node_modules/leveldown && cross-env HOME=~/.electron-gyp node-gyp rebuild --target=2.0.7 --runtime=electron --arch=x64 --dist-url=https://atom.io/download/atom-shell",
     "license-check": "license-check"
   },
-  "license": "GPL-v3.0",
+  "license": "GPL-3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/digidem/mapeo-desktop.git"


### PR DESCRIPTION
Resolves the minor warning " warn mapeo-desktop@4.0.4-beta license should be a valid SPDX license expression" See https://spdx.org/licenses/ for more description. 

This field is also used  for generating .deb package metadata  #219