### PR TITLE
Adding GH_TOKEN step to build process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ or keyboard while the tests are running.
 Mapeo uses [Electron](http://electron.atom.io/). To package the Electron app as
 a native Windows `.exe` or macOS `.dmg`, execute
 
+Please generate a GitHub access token from https://github.com/settings/tokens/new and assign it to an environment variable with ```export GH_TOKEN="<TOKEN_HERE>```
+
 ```
 $ npm run pack
 ```


### PR DESCRIPTION
I think it is essential for new contributors to export a GH_TOKEN before they do 'npm run dist'.