### PR TITLE
Correct leveldb electron rebuild target to 2.0.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "server": "node index.js --headless",
     "dev": "electron . --debug --disable-http-cache",
     "postinstall": "electron-builder install-app-deps && npmpd",
-    "rebuild-leveldb": "cd node_modules/leveldown && cross-env HOME=~/.electron-gyp node-gyp rebuild --target=2.0.18 --runtime=electron --arch=x64 --dist-url=https://atom.io/download/atom-shell",
+    "rebuild-leveldb": "cd node_modules/leveldown && cross-env HOME=~/.electron-gyp node-gyp rebuild --target=2.0.18 --runtime=electron --dist-url=https://atom.io/download/atom-shell",
     "license-check": "license-check"
   },
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "server": "node index.js --headless",
     "dev": "electron . --debug --disable-http-cache",
     "postinstall": "electron-builder install-app-deps && npmpd",
-    "rebuild-leveldb": "cd node_modules/leveldown && cross-env HOME=~/.electron-gyp node-gyp rebuild --target=2.0.7 --runtime=electron --arch=x64 --dist-url=https://atom.io/download/atom-shell",
+    "rebuild-leveldb": "cd node_modules/leveldown && cross-env HOME=~/.electron-gyp node-gyp rebuild --target=2.0.18 --runtime=electron --arch=x64 --dist-url=https://atom.io/download/atom-shell",
     "license-check": "license-check"
   },
   "license": "GPL-3.0",


### PR DESCRIPTION
Correctly target the latest electron stable release [2.0.18](
https://electronjs.org/releases/stable?version=2#2.0.18) resolves the problem running mapeo-desktop on windows 32-bit systems.  

Fixes https://github.com/digidem/mapeo-desktop/issues/238