### PR TITLE
Remove --arch=x64 option

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "server": "node index.js --headless",
     "dev": "electron . --debug --disable-http-cache",
     "postinstall": "electron-builder install-app-deps && npmpd",
-    "rebuild-leveldb": "cd node_modules/leveldown && cross-env HOME=~/.electron-gyp node-gyp rebuild --target=2.0.7 --runtime=electron --arch=x64 --dist-url=https://atom.io/download/atom-shell",
+    "rebuild-leveldb": "cd node_modules/leveldown && cross-env HOME=~/.electron-gyp node-gyp rebuild --target=2.0.7 --runtime=electron --dist-url=https://atom.io/download/atom-shell",
     "license-check": "license-check"
   },
   "license": "GPL-3.0",


### PR DESCRIPTION
Removing "--arch=x64" hard limit would allow building and running integration tests on windows 32-bit machines. Without this option, the arch setting will be picked from environment.  

Fixes https://github.com/digidem/mapeo-desktop/issues/237

Tested on Windows 7 32-bit machine 