### PR TITLE
Yarn TravisCI Multi-OS builds 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,57 @@
-sudo: false
+
 language: node_js
 node_js:
-  - '8'
+  - '8' # EOL: December 2019
+  # Please enable these matrix values after bug #228 is fixed
+  #- '10' # EOL: April 2021
+  #- '11' # EOL: June 2019
 
-os:
-  - osx
-  - linux
+env:
+  global:
+    - ELECTRON_CACHE=$HOME/.cache/electron
+    - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
 
-env: 
-  TEST_SCREENSHOTS=false
+cache:
+  yarn: true
+  directories:
+    - $HOME/.cache/electron
+    - $HOME/.cache/electron-builder
+    - $HOME/.electron-gyp
 
-script:
-  - npm rebuild
-  - npm run rebuild-leveldb
-  - npm run lint
-  - npm run build
-  - npm run dist
+matrix:
+  fast_finish: true
+  allow_failures:
+    - os: windows
+  include:
+    - os: linux
+    - os: osx
+      osx_image: xcode10.2
+    - os: windows
+      env: YARN_GPG=no # Travis-CI Bug: gpg-agent hangs build task in windows
+      cache: false     # Travis-CI Bug: cache stage fails to mount in windows
 
-addons:
-  apt:
-    packages:
-      - xvfb
+# Use Yarn stable version 1.17.3 instead of Travis CI default 1.3.2
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.17.3
+  - export PATH="$HOME/.yarn/bin:$PATH"
+# Workaround for Network connection errors
+  - yarn config delete proxy
+  - npm config rm proxy
+  - npm config rm https-proxy
+  - yarn config set network-timeout 1000000
 
 install:
-  - export DISPLAY=':99.0'
-  - Xvfb :99 -screen 0 1280x1024x16 > /dev/null 2>&1 &
-  - npm install
+  - travis_retry yarn --frozen-lockfile --non-interactive --check-files --network-timeout 100000
+
+script:
+  - yarn run rebuild-leveldb
+  - yarn run lint
+  - yarn run build
+  - yarn run dist
 
 deploy:
   provider: script
-  script: npm run dist
+  script: yarn run dist
   on:
     all_branches: true
   skip_cleanup: true


### PR DESCRIPTION
TravisCI yarn based multiple OS build matrix with gnu/Linux, MS Windows and Mac NPM is very unreliable on Windows OS

* Using Yarn stable version 1.17.3 instead of TravisCI default.
* TravisCI patch to fix Yarn network connection timeouts.
* TravisCI patch to fix Yarn GPG-agent errors on windows.
* TravisCI caching disabled on windows due to mount failures.

Fixes:  https://github.com/digidem/mapeo-desktop/issues/204