### PR TITLE
Use randomBytes from 'crypto' instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "osm-p2p-server": "^4.0.0",
     "prop-types": "^15.6.0",
     "pump": "^1.0.3",
-    "randombytes": "^2.0.6",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
     "react-intl": "^2.7.2",

--- a/src/renderer/components/MapFilter.js
+++ b/src/renderer/components/MapFilter.js
@@ -10,7 +10,7 @@ import differenceBy from 'lodash/differenceBy'
 import url from 'url'
 
 import MenuItem from '@material-ui/core/MenuItem'
-import randomBytes from 'randombytes'
+import { randomBytes } from 'crypto'
 
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles'
 


### PR DESCRIPTION
Use randomBytes from Node.js 'crypto' directly instead of randombytes
npm package.

Fix for randomBytes webpack error https://github.com/digidem/mapeo-desktop/issues/242

```
ERROR in ./src/renderer/components/MapFilter.js

Module not found: Error: Can't resolve 'randombytes' in
'/Users/travis/build/arky/mapeo-desktop/src/renderer/components'

 @ ./src/renderer/components/MapFilter.js 33:19-41

 @ ./src/renderer/components/Home.js

 @ ./src/renderer/app.js
```

@gmaclennan  Please kindly review