### PR TITLE
Replace 'lodash' with 'lodash-es'

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "insert-css": "^1.0.0",
     "level": "^1.4.0",
     "levelup": "^1.3.1",
-    "lodash": "^4.17.4",
+    "lodash-es": "^4.17.15",
     "mapeo-server": "^16.0.0",
     "mapeo-styles": "^3.0.0",
     "minimist": "^1.2.0",


### PR DESCRIPTION
Using ES version of lodash resolves webpack errors in Mac OSX as shown
in https://github.com/digidem/mapeo-desktop/issues/242