### PR TITLE
Enclose tile-dl output paramters in double quotes

### DIFF
--- a/docs/offline_tiles.md
+++ b/docs/offline_tiles.md
@@ -63,7 +63,7 @@ $ tile-dl -t "$(cat url_template)" --lon=-122.2632601 --lat=37.8027446 \
 ```
 On Windows
 ``` cmd
-tile-dl -t %url_template% --lon=-122.2632601 --lat=37.8027446 --radius 0.1 --zoom 12 --output tiles/{z}/{x}/{y}.png
+tile-dl -t %url_template% --lon=-122.2632601 --lat=37.8027446 --radius 0.1 --zoom 12 --output "tiles/{z}/{x}/{y}.png"
 ```
 
 This example downloads the area around Oakland, California. You can tweak the


### PR DESCRIPTION
In Windows Powershell the output parameters needs to be within double quotes ( " " ). I believe otherwise the curly braces ({}) are interpreted as Unicode escape sequence