### PR TITLE
fix: Fix builds on Windows

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,6 +23,7 @@ jobs:
       run: |
         npm install
         npm run lint
+        npm run rebuild-leveldb
         npm run build
       env:
         CI: true

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "start": "electron . --disable-http-cache",
     "server": "node index.js --headless",
     "dev": "electron . --debug --disable-http-cache",
-    "postinstall": "electron-builder install-app-deps && npmpd && electron-rebuild",
+    "postinstall": "electron-builder install-app-deps && npmpd",
+    "rebuild-leveldb": "electron-rebuild -o leveldown",
     "license-check": "license-check",
     "release": "standard-version",
     "release:beta": "standard-version --prerelease beta"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "start": "electron . --disable-http-cache",
     "server": "node index.js --headless",
     "dev": "electron . --debug --disable-http-cache",
-    "postinstall": "electron-builder install-app-deps && npmpd",
+    "postinstall": "electron-builder install-app-deps && npmpd && electron-rebuild",
     "license-check": "license-check",
     "release": "standard-version",
     "release:beta": "standard-version --prerelease beta"
@@ -129,6 +129,7 @@
     "devtron": "^1.2.0",
     "electron": "^2.0.7",
     "electron-builder": "^20.8.1",
+    "electron-rebuild": "^1.8.6",
     "fs-extra": "^0.30.0",
     "hubfs.js": "^1.0.0",
     "license-check": "^1.1.5",


### PR DESCRIPTION
`electron-builder install-app-deps` does not seem to correctly rebuild deps on Windows, this hopefully fixes it.

The goal of using `electron-rebuild` instead of a manual rebuild command is to avoid errors because `leveldown` isn't always in `node_modules/leveldown` and to avoid errors when changing electron versions.