### PR TITLE
fix: Remove asar from the import menu

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -54,7 +54,7 @@ jobs:
       #   env:
       #     GH_RELEASE_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}
       - name: Update website release
-        if: contains(github.ref '/tags/')
+        if: contains(github.ref, '/tags/')
         run: bin/release_latest.js
         env:
           GITHUB_TOKEN: ${{ secrets.WEBSITE_GH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To clone and install all dependencies and start a process to re-build the app wh
 git clone git@github.com:digidem/mapeo-desktop.git
 cd mapeo-desktop
 npm install
+npm run build:translations
 npm run watch
 ```
 

--- a/messages/main/en.json
+++ b/messages/main/en.json
@@ -9,7 +9,7 @@
   "menu-file": "File",
   "menu-change-language": "Change language...",
   "menu-change-language-title": "Enter the language (e.g., 'en' or 'es')",
-  "menu-import-tiles-file": "File (.asar, .tar)",
+  "menu-import-tiles-file": "File (.tar)",
   "menu-import-tiles-directory": "Directory of tiles",
   "menu-import-tiles": "Import Offline Map Tiles...",
   "menu-import-tiles-error": "Could not import tiles",

--- a/messages/main/es.json
+++ b/messages/main/es.json
@@ -9,7 +9,7 @@
   "menu-file": "Archivo",
   "menu-change-language": "Cambiar idioma...",
   "menu-change-language-title": "Ingrese el idioma (e.g., 'en' or 'es')",
-  "menu-import-tiles-file": "Archivo (.asar, .tar)",
+  "menu-import-tiles-file": "Archivo (.tar)",
   "menu-import-tiles-directory": "Carpeta",
   "menu-import-tiles": "Importar Offline Map Tiles...",
   "menu-import-tiles-error": "No pudo importar archivo",

--- a/messages/main/fr.json
+++ b/messages/main/fr.json
@@ -9,7 +9,7 @@
   "menu-file": "File",
   "menu-change-language": "Change language...",
   "menu-change-language-title": "Enter the language (e.g., 'en' or 'es')",
-  "menu-import-tiles-file": "File (.asar, .tar)",
+  "menu-import-tiles-file": "File (.tar)",
   "menu-import-tiles-directory": "Directory of tiles",
   "menu-import-tiles": "Import Offline Map Tiles...",
   "menu-import-tiles-error": "Could not import tiles",

--- a/messages/main/pt.json
+++ b/messages/main/pt.json
@@ -9,7 +9,7 @@
   "menu-file": "Archivo",
   "menu-change-language": "Cambiar idioma...",
   "menu-change-language-title": "Ingrese el idioma (e.g., 'en' or 'es')",
-  "menu-import-tiles-file": "Archivo (.asar, .tar)",
+  "menu-import-tiles-file": "Archivo (.tar)",
   "menu-import-tiles-directory": "Carpeta",
   "menu-import-tiles": "Importar Offline Map Tiles...",
   "menu-import-tiles-error": "No pudo importar archivo",

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -30,7 +30,6 @@ function menuTemplate (context) {
               title: t('menu-import-tiles'),
               properties: ['openFile'],
               filters: [
-                { name: 'Electron Asar', extensions: ['asar'] },
                 { name: 'Tar', extensions: ['tar'] }
               ]
             }

--- a/src/main/tile-importer.js
+++ b/src/main/tile-importer.js
@@ -82,6 +82,7 @@ TileImporter.prototype.moveTiles = function (tilesPath, tilesDest, cb) {
     if (err) return cb(err)
     mkdirp(tilesDest, err => {
       if (err) return cb(err)
+      // TODO: deprecate asar support
       if (path.extname(tilesPath) === '.asar') {
         var filename = path.basename(tilesPath)
         // because electron treats asar as a folder, not a file.


### PR DESCRIPTION
### Context
On a mac, when you try to import custom tiles, the option for using tar files was not visible in the UI. Since asar compatibility will be [deprecated soon](https://github.com/digidem/mapeo-server/issues/53), this PR removes it from the default menu options.
The tar format will now be the default format for uploading tiles, and this, combined with the [tilserver port change in id-mapeo](https://github.com/digidem/iD-mapeo/pull/9) fixes this issue: https://github.com/digidem/mapeo-desktop/issues/261


cc @gmaclennan @okdistribute 