### PR TITLE
fix: Fix Windows CI/CD for automated builds

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -60,7 +60,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.WEBSITE_GH_TOKEN }}
       - name: Cleanup artifacts
         run: |
-          npx rimraf 'dist/!(*.exe|*.deb|*.AppImage|*.dmg)'
+          npx rimraf@2 'dist/!(*.exe|*.deb|*.AppImage|*.dmg)'
         shell: bash
       - name: Upload artifacts
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
No idea why rimraf v3 broke this, but pinning to v2 seems to work