### PR TITLE
fix: Fix flickering of devices in sync screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "core-js": "^3.3.5",
     "d3-dsv": "^1.1.1",
     "date-fns": "^2.1.0",
+    "discovery-swarm": "6.0.0",
     "ecstatic": "^2.2.1",
     "electron-context-menu": "^0.15.0",
     "electron-debug": "^1.5.0",


### PR DESCRIPTION
Fixes https://github.com/digidem/mapeo-desktop/issues/276

This should have been in 5.0.3 but for some reason was missing (https://github.com/digidem/mapeo-desktop/issues/276)

## Bug:

Devices were appearing and disappearing in the sync screen on desktop

## Fix:

Pin [discovery-swarm](https://github.com/mafintosh/discovery-swarm) to v6.0.0 because the error seems to come from an issue in the latest discovery swarm.
