### PR TITLE
fix: only one window at a time during startup.

### DIFF
--- a/index.js
+++ b/index.js
@@ -282,6 +282,8 @@ function notifyReady (done) {
       var IS_TEST = process.env.NODE_ENV === 'test'
       if (IS_TEST) win.setSize(1000, 800, false)
       if (argv.debug) win.webContents.openDevTools()
+
+      win.maximize()
       splash.destroy()
       win.show()
       done()

--- a/splash.html
+++ b/splash.html
@@ -10,10 +10,10 @@
   <body>
   <div id="welcome" class='mapeo-container'>
     <div id="screen-1">
+      <img src='static/mapeo_256x256.png' />
       <h1>
         Cargando...
       </h1>
-      <img src='static/mapeo_256x256.png' />
     </div>
   </div>
   </body>

--- a/src/main/window-state.js
+++ b/src/main/window-state.js
@@ -5,8 +5,8 @@ const electron = require('electron')
 const store = require('../store')
 
 const defaults = {
-  maximize: true,
-  fullscreen: true,
+  maximize: false,
+  fullscreen: false,
   defaultWidth: 800,
   defaultHeight: 600,
   isMaximized: true

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -1,5 +1,5 @@
 :root {
-  --main-bg-color: rgb(57, 82, 123);
+  --main-bg-color: rgba(51, 102, 255);
   --secondary-bg-color: blue;
   --main-bg-color-alpha: rgba(57, 82, 123, 0.5);
   --visible-z-index: 100;


### PR DESCRIPTION
fixes #283



### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Mapeo Crowdin project](https://crowdin.com/project/mapeo-desktop)_
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] I have walked through the [QA Manual Testing
  Script](https://github.com/digidem/mapeo-desktop/blob/master/docs/testing.md) and updated it if necessary.
- [x] If my changes depend upon an update to a dependency, I have updated the package-lock.json file using `npm install --package-lock`
- [x] My changes have been tested with the [mobile app](https://github.com/digidem/mapeo-mobile/releases). 
- [x] My changes are ready to be shipped to users on Windows, Mac, and Linux

### Description

Tested this on my linux laptop.

This bug was introduced with the new window state manager.