### PR TITLE
fix: Mapeo no longer crashes on hybrid graphics cards

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,9 +27,6 @@ var windowStateKeeper = require('./src/main/window-state')
 var installStatsIndex = require('./src/main/osm-stats')
 var TileImporter = require('./src/main/tile-importer')
 
-// HACK: enable GPU graphics acceleration on some older laptops
-app.commandLine.appendSwitch('ignore-gpu-blacklist', 'true')
-
 // Setup some handy dev tools shortcuts (only activates in dev mode)
 // See https://github.com/sindresorhus/electron-debug
 debug({ showDevTools: false })


### PR DESCRIPTION

<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->


### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Mapeo Crowdin project](https://crowdin.com/project/mapeo-desktop)_
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] I have walked through the [QA Manual Testing
  Script](https://github.com/digidem/mapeo-desktop/blob/master/docs/testing.md) and updated it if necessary.
- [x] If my changes depend upon an update to a dependency, I have updated the package-lock.json file using `npm install --package-lock`
- [NA] My changes have been tested with the [mobile app](https://github.com/digidem/mapeo-mobile/releases). 
- [ ] My changes are ready to be shipped to users on Windows, Mac, and Linux

### Description

Reported by @arky that on some Windows machines with NVIDIA graphics,
Mapeo would crash on startup. This line was originally added by @noffle
but now on this version of electron doesn't seem necessary. fixes #279
