### PR TITLE
Change language dialog

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -249,5 +249,8 @@
   },
   "renderer.components.dialogs.LatLon.dialog-enter-latlon-coordinates": {
     "message": "Enter Coordinates"
+  },
+  "renderer.components.dialogs.ChangeLanguage.dialog-enter-language": {
+    "message": "Choose a Language"
   }
 }

--- a/src/main/i18n.js
+++ b/src/main/i18n.js
@@ -1,6 +1,7 @@
 const { EventEmitter } = require('events')
 const { app } = require('electron')
 const logger = require('../logger')
+const store = require('../store')
 
 const translations = {
   en: require('../../messages/main/en.json'),
@@ -48,6 +49,7 @@ class I18n extends EventEmitter {
     this.locale = newLocale
     this.genericLocale = newLocale.split('-')[0]
     this.emit('locale-change', newLocale)
+    store.set('locale', newLocale)
   }
 }
 
@@ -55,5 +57,9 @@ const i18n = new I18n('en')
 module.exports = i18n
 
 app.once('ready', () => {
-  i18n.setLocale(app.getLocale())
+  try {
+    i18n.setLocale(store.get('locale'))
+  } catch (err) {
+    i18n.setLocale(app.getLocale())
+  }
 })

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -29,8 +29,12 @@ module.exports = function (win) {
     ipcSend('error', message)
   })
 
-  ipc.on('set-locale', function (ev, lang) {
-    app.translations = i18n.setLocale(lang)
+  ipc.on('set-locale', function (ev, locale) {
+    app.translations = i18n.setLocale(locale)
+  })
+
+  ipc.on('get-locale', function (ev) {
+    ev.returnValue = i18n.locale
   })
 
   ipc.on('import-example-presets', function (ev) {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import { ipcRenderer } from 'electron'
 import { StylesProvider, ThemeProvider } from '@material-ui/styles'
 import { IntlProvider } from 'react-intl'
 import CssBaseline from '@material-ui/core/CssBaseline'
@@ -8,7 +9,7 @@ import logger from '../logger'
 import theme from './theme'
 import Home from './components/Home'
 
-const locale = navigator.language.slice(0, 2)
+const locale = ipcRenderer.sendSync('get-locale') // navigator.language.slice(0, 2)
 
 const mdMsgs = {
   en: require('../../translations/en.json'),

--- a/src/renderer/components/Home.js
+++ b/src/renderer/components/Home.js
@@ -14,6 +14,7 @@ import {
 import pkg from '../../../package.json'
 import MapEditor from './MapEditor'
 import LatLonDialog from './dialogs/LatLon'
+import ChangeLanguage from './dialogs/ChangeLanguage'
 import TitleBarShim from './TitleBarShim'
 import MapFilter from './MapFilter'
 import { defineMessages, useIntl } from 'react-intl'
@@ -163,11 +164,14 @@ export default function Home () {
 
   React.useEffect(() => {
     const openLatLonDialog = () => setDialog('LatLon')
+    const openChangeLangDialog = () => setDialog('ChangeLanguage')
     const refreshPage = () => window.location.reload()
     ipcRenderer.on('open-latlon-dialog', openLatLonDialog)
+    ipcRenderer.on('change-language-request', openChangeLangDialog)
     ipcRenderer.on('force-refresh-window', refreshPage)
     return () => {
       ipcRenderer.removeListener('open-latlon-dialog', openLatLonDialog)
+      ipcRenderer.removeListener('change-language-request', openChangeLangDialog)
       ipcRenderer.removeListener('force-refresh-window', openLatLonDialog)
     }
   }, [])
@@ -197,6 +201,13 @@ export default function Home () {
         <TabPanel value={tabIndex} index={1} component={MapFilter} />
         <TabPanel value={tabIndex} index={2} component={SyncView} />
       </TabContent>
+      <ChangeLanguage
+        open={dialog === 'ChangeLanguage'}
+        onClose={() => {
+          setDialog(null)
+          ipcRenderer.send('force-refresh-window') // TODO: can we do this without sending ipc?
+        }}
+      />
       <LatLonDialog
         open={dialog === 'LatLon'}
         onClose={() => setDialog(null)}

--- a/src/renderer/components/MapEditor/index.js
+++ b/src/renderer/components/MapEditor/index.js
@@ -270,49 +270,6 @@ const MapEditor = () => {
 
 export default MapEditor
 
-// refreshWindow () {
-//   if (this.id) {
-//     var history = this.id.history()
-//     var saved = history.toJSON()
-//     this.id.flush()
-//     if (saved) history.fromJSON(saved)
-//     ipcRenderer.send('zoom-to-data-get-centroid', 'node')
-//   }
-// }
-
-// zoomToLatLonResponse (_, lat, lon) {
-//   var self = this
-//   self.id.map().centerEase([lat, lon], 1000)
-//   setTimeout(function () {
-//     self.id.map().zoom(15)
-//   }, 1000)
-// }
-
-// zoomToDataRequest () {
-//   ipcRenderer.send('zoom-to-data-get-centroid', 'node')
-// }
-
-// zoomToDataResponse (_, loc) {
-//   var self = this
-//   var zoom = 14
-//   self.id.map().centerEase(loc, 1000)
-//   setTimeout(function () {
-//     self.id.map().zoom(zoom)
-//   }, 1000)
-// }
-
-// changeLanguageRequest () {
-//   var self = this
-//   var dialogs = Dialogs()
-//   dialogs.prompt(i18n('menu-change-language-title'), function (locale) {
-//     if (locale) {
-//       self.setState({ locale })
-//       ipcRenderer.send('set-locale', locale)
-//       self.id.ui().restart(locale)
-//     }
-//   })
-// }
-
 function latlonToPosString (pos) {
   pos[0] = (Math.floor(pos[0] * 1000000) / 1000000).toString()
   pos[1] = (Math.floor(pos[1] * 1000000) / 1000000).toString()

--- a/src/renderer/components/dialogs/ChangeLanguage.js
+++ b/src/renderer/components/dialogs/ChangeLanguage.js
@@ -1,0 +1,63 @@
+import DialogActions from '@material-ui/core/DialogActions'
+import Button from '@material-ui/core/Button'
+import Select from '@material-ui/core/Select'
+import Dialog from '@material-ui/core/Dialog'
+import MenuItem from '@material-ui/core/MenuItem'
+import DialogContent from '@material-ui/core/DialogContent'
+import DialogTitle from '@material-ui/core/DialogTitle'
+import FormControl from '@material-ui/core/FormControl'
+import React, { useState } from 'react'
+import { ipcRenderer } from 'electron'
+
+import { defineMessages, useIntl } from 'react-intl'
+
+const languages = {
+  es: 'Español',
+  en: 'English',
+  fr: 'Français',
+  pt: 'Português'
+}
+
+const m = defineMessages({
+  'dialog-enter-language': 'Choose a language',
+  'button-submit': 'Submit'
+})
+
+const ChangeLanguage = ({ onClose, open }) => {
+  const { formatMessage: t } = useIntl()
+  const [lang, setLang] = useState()
+
+  const submitHandler = event => {
+    ipcRenderer.send('set-locale', lang)
+    onClose()
+    if (event) {
+      event.preventDefault()
+      event.stopPropagation()
+    }
+    return false
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>{t(m['dialog-enter-language'])}</DialogTitle>
+      <DialogContent>
+        <FormControl>
+          <Select
+            id='dialog-change-language'
+            value={lang}
+            onChange={event => setLang(event.target.value)}
+          >
+            {Object.keys(languages).map((code) => (
+              <MenuItem key={code} value={code}>{languages[code]} ({code})</MenuItem>
+            ))}
+          </Select>
+          <DialogActions>
+            <Button onClick={submitHandler}>{t(m['button-submit'])}</Button>
+          </DialogActions>
+        </FormControl>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default ChangeLanguage


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Mapeo Crowdin project](https://crowdin.com/project/mapeo-desktop)_
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] I have walked through the [QA Manual Testing
  Script](https://github.com/digidem/mapeo-desktop/blob/master/docs/testing.md) and updated it if necessary.
- [x] If my changes depend upon an update to a dependency, I have updated the package-lock.json file using `npm install --package-lock`
- ~[ ] My changes have been tested with the [mobile app](https://github.com/digidem/mapeo-mobile/releases).~ N/A
- [x] My changes are ready to be shipped to users on Windows, Mac, and Linux

### Description

This re-implements the change language dialog in mapeo desktop. fixes #263, #149, #148  

### TODO
- [x] Automatically select the language you're currently on