### PR TITLE
fix: win32 builds bundled into the windows release

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Lint
         run: |
           npm run lint
-      - name: Rebuild native deps for Electron
-        run: |
-          npm run rebuild-leveldb
       - name: Build frontend
         run: |
           npm run build

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "server": "node index.js --headless",
     "dev": "electron . --debug --disable-http-cache",
     "postinstall": "patch-package && electron-builder install-app-deps",
-    "rebuild-leveldb": "electron-rebuild -o leveldown",
     "license-check": "license-check",
     "release": "standard-version",
     "release:beta": "standard-version --prerelease beta",
@@ -146,7 +145,6 @@
     "electron": "^6.0.10",
     "electron-builder": "^21.2.0",
     "electron-devtools-installer": "^2.2.4",
-    "electron-rebuild": "^1.8.6",
     "eslint": "^6.4.0",
     "eslint-config-standard": "^14.1.0",
     "eslint-plugin-import": "^2.18.2",
@@ -200,6 +198,17 @@
         "deb"
       ],
       "category": "Utility"
+    },
+    "win": {
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
+        }
+      ]
     },
     "dmg": {
       "icon": "build/mapeo_installer.icns",


### PR DESCRIPTION
# Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Mapeo Crowdin project](https://crowdin.com/project/mapeo-desktop)_
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] I have walked through the [QA Manual Testing
  Script](https://github.com/digidem/mapeo-desktop/blob/master/docs/testing.md) and updated it if necessary.
- [x] If my changes depend upon an update to a dependency, I have updated the package-lock.json file using `npm install --package-lock`
- [ ] My changes have been tested with the [mobile app](https://github.com/digidem/mapeo-mobile/releases).
- [x] My changes are ready to be shipped to users on Windows, Mac, and Linux

### Description

Windows 32-bit builds will now work, with leveldown@5.6.0.

This raises the size of the Windows build. I wonder if we want to separate the builds into two executables (win32 and x64), which would make them ~75mb each.

Pros: Smaller downloads, faster on sluggish internet.
Cons: Multiple options to decide upon, could download the wrong one if not careful.
 -> to mitigate this con, we can update the [download page](https://digital-democracy/mapeo) to automatically find out if you're on 32 or 64 bit machine and suggest the correct one for you.

Should we separate the windows build into 32 and 64 bit versions?