### PR TITLE
fix: Small fixes to language switcher

### DIFF
--- a/src/renderer/components/Home.js
+++ b/src/renderer/components/Home.js
@@ -157,7 +157,7 @@ function TabPanel (props) {
 
 const useTabIndex = createPersistedState('currentView')
 
-export default function Home () {
+export default function Home ({ onSelectLanguage }) {
   const [dialog, setDialog] = React.useState()
   const [tabIndex, setTabIndex] = useTabIndex(0)
   const { formatMessage: t } = useIntl()
@@ -171,7 +171,10 @@ export default function Home () {
     ipcRenderer.on('force-refresh-window', refreshPage)
     return () => {
       ipcRenderer.removeListener('open-latlon-dialog', openLatLonDialog)
-      ipcRenderer.removeListener('change-language-request', openChangeLangDialog)
+      ipcRenderer.removeListener(
+        'change-language-request',
+        openChangeLangDialog
+      )
       ipcRenderer.removeListener('force-refresh-window', openLatLonDialog)
     }
   }, [])
@@ -203,9 +206,12 @@ export default function Home () {
       </TabContent>
       <ChangeLanguage
         open={dialog === 'ChangeLanguage'}
-        onClose={() => {
+        onCancel={() => {
           setDialog(null)
-          ipcRenderer.send('force-refresh-window') // TODO: can we do this without sending ipc?
+        }}
+        onSelectLanguage={lang => {
+          onSelectLanguage(lang)
+          setDialog(null)
         }}
       />
       <LatLonDialog

--- a/src/renderer/components/MapEditor/index.js
+++ b/src/renderer/components/MapEditor/index.js
@@ -99,7 +99,7 @@ const MapEditor = () => {
   const rootRef = React.useRef()
   const id = React.useRef()
   const customDefs = React.useRef()
-  const { formatMessage: t } = useIntl()
+  const { formatMessage: t, locale } = useIntl()
   const [toolbarEl, setToolbarEl] = React.useState()
 
   const zoomToData = React.useCallback((_, loc) => {
@@ -160,6 +160,10 @@ const MapEditor = () => {
         .assetPath('node_modules/id-mapeo/dist/')
         .preauth({ url: serverUrl })
         .minEditableZoom(window.localStorage.getItem('minEditableZoom') || 14)
+
+      // Calling iD.coreContext() detects the locale from the browser. We need
+      // to override it with the app locale, before we call ui()
+      id.current.locale(locale)
 
       if (!customDefs.current) {
         customDefs.current = id.current

--- a/src/renderer/components/MapEditor/index.js
+++ b/src/renderer/components/MapEditor/index.js
@@ -228,7 +228,12 @@ const MapEditor = () => {
         // setTimeout(() => id.current.flush(), 1500)
       })
     },
-    [t]
+    // This should have a dependency of `t` and `locale`, so that it re-runs if
+    // the locale or the `t` function changes, but we don't have an easy way to
+    // teardown iD editor and then recreate it, so we need to never re=-run this
+    // effect
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
   )
 
   function updateSettings () {

--- a/src/renderer/components/dialogs/ChangeLanguage.js
+++ b/src/renderer/components/dialogs/ChangeLanguage.js
@@ -24,30 +24,24 @@ const m = defineMessages({
   'button-cancel': 'Cancel'
 })
 
-const ChangeLanguage = ({ onClose, open }) => {
+const ChangeLanguage = ({ onCancel, onSelectLanguage, open }) => {
   const { formatMessage: t, locale } = useIntl()
   // Set default state to app locale
   const [lang, setLang] = useState(locale)
 
-  const submitHandler = event => {
-    ipcRenderer.send('set-locale', lang)
-    onClose()
-    if (event) {
-      event.preventDefault()
-      event.stopPropagation()
-    }
-    return false
+  const submitHandler = () => {
+    onSelectLanguage(lang)
   }
 
   const closeHandler = () => {
     // This will remember state between open/close, so if the user cancels this
     // should reset to the currently selected locale
     setLang(locale)
-    onClose()
+    onCancel()
   }
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth='xs'>
+    <Dialog open={open} onClose={onCancel} fullWidth maxWidth='xs'>
       <DialogTitle>{t(m['dialog-enter-language'])}</DialogTitle>
       <DialogContent>
         <FormControl>

--- a/src/renderer/components/dialogs/ChangeLanguage.js
+++ b/src/renderer/components/dialogs/ChangeLanguage.js
@@ -20,7 +20,8 @@ const languages = {
 
 const m = defineMessages({
   'dialog-enter-language': 'Choose a language',
-  'button-submit': 'Submit'
+  'button-submit': 'Submit',
+  'button-cancel': 'Cancel'
 })
 
 const ChangeLanguage = ({ onClose, open }) => {
@@ -38,8 +39,15 @@ const ChangeLanguage = ({ onClose, open }) => {
     return false
   }
 
+  const closeHandler = () => {
+    // This will remember state between open/close, so if the user cancels this
+    // should reset to the currently selected locale
+    setLang(locale)
+    onClose()
+  }
+
   return (
-    <Dialog open={open} onClose={onClose}>
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth='xs'>
       <DialogTitle>{t(m['dialog-enter-language'])}</DialogTitle>
       <DialogContent>
         <FormControl>
@@ -54,11 +62,16 @@ const ChangeLanguage = ({ onClose, open }) => {
               </MenuItem>
             ))}
           </Select>
-          <DialogActions>
-            <Button onClick={submitHandler}>{t(m['button-submit'])}</Button>
-          </DialogActions>
         </FormControl>
       </DialogContent>
+      <DialogActions>
+        <Button color='default' onClick={closeHandler}>
+          {t(m['button-cancel'])}
+        </Button>
+        <Button color='primary' onClick={submitHandler}>
+          {t(m['button-submit'])}
+        </Button>
+      </DialogActions>
     </Dialog>
   )
 }

--- a/src/renderer/components/dialogs/ChangeLanguage.js
+++ b/src/renderer/components/dialogs/ChangeLanguage.js
@@ -7,7 +7,6 @@ import DialogContent from '@material-ui/core/DialogContent'
 import DialogTitle from '@material-ui/core/DialogTitle'
 import FormControl from '@material-ui/core/FormControl'
 import React, { useState } from 'react'
-import { ipcRenderer } from 'electron'
 
 import { defineMessages, useIntl } from 'react-intl'
 

--- a/src/renderer/components/dialogs/ChangeLanguage.js
+++ b/src/renderer/components/dialogs/ChangeLanguage.js
@@ -24,8 +24,9 @@ const m = defineMessages({
 })
 
 const ChangeLanguage = ({ onClose, open }) => {
-  const { formatMessage: t } = useIntl()
-  const [lang, setLang] = useState()
+  const { formatMessage: t, locale } = useIntl()
+  // Set default state to app locale
+  const [lang, setLang] = useState(locale)
 
   const submitHandler = event => {
     ipcRenderer.send('set-locale', lang)
@@ -47,8 +48,10 @@ const ChangeLanguage = ({ onClose, open }) => {
             value={lang}
             onChange={event => setLang(event.target.value)}
           >
-            {Object.keys(languages).map((code) => (
-              <MenuItem key={code} value={code}>{languages[code]} ({code})</MenuItem>
+            {Object.keys(languages).map(code => (
+              <MenuItem key={code} value={code}>
+                {languages[code]} ({code})
+              </MenuItem>
             ))}
           </Select>
           <DialogActions>


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/digidem/mapeo-desktop/blob/master/README.md) 

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Mapeo Crowdin project](https://crowdin.com/project/mapeo-desktop)_
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [ ] I have walked through the [QA Manual Testing
  Script](https://github.com/digidem/mapeo-desktop/blob/master/docs/testing.md) and updated it if necessary.
- [ ] If my changes depend upon an update to a dependency, I have updated the package-lock.json file using `npm install --package-lock`
- [ ] My changes have been tested with the [mobile app](https://github.com/digidem/mapeo-mobile/releases). 
- [ ] My changes are ready to be shipped to users on Windows, Mac, and Linux

### Description

Some small fixes to the language switch dialog:

- Show the currently selected locale
- Allow the user to cancel language switch

Also wrote code to change language without a force-refresh, but our iD Editor integration with React was unhappy (iD re-renders everything when you switch language, and we have a React component patched into the iD toolbar).
