### PR TITLE
fix: Improve conversion of Mapeo presets for iD Editor

### DIFF
--- a/src/renderer/components/MapEditor/index.js
+++ b/src/renderer/components/MapEditor/index.js
@@ -377,14 +377,25 @@ function convertPresets (presetsObj) {
     let type
     let snakeCase
     switch (field.type) {
+      // The iD equivalent of the mapeo select_one is a `combo` field
       case 'select_one':
         type = 'combo'
+        // iD defaults to combo fields being "snake case", which means that it
+        // converts any value selected / entered to snake case. Mapeo defaults
+        // snake_case to false.
         snakeCase =
           typeof field.snake_case === 'boolean' ? field.snake_case : false
         break
+      // iD equivalent of select_multiple is `semiCombo`, but note that iD
+      // stores the value as a semi-colon separated string, whereas Mapeo will
+      // store this as an array, so this field is not compatible between the
+      // two.
       case 'select_multiple':
         type = 'semiCombo'
         break
+      // Mapeo does not have a `textarea` field, instead text fields have an
+      // appearance of `singleline` or `multiline`, with the default
+      // `multiline`.
       case 'text':
         if (!field.appearance || field.appearance === 'multiline') {
           type = 'textarea'
@@ -399,6 +410,13 @@ function convertPresets (presetsObj) {
       type,
       snake_case: snakeCase
     }
+
+    // Mapeo supports translatable descriptions of field values for select
+    // fields with an array of option objects with "label" and "value"
+    // properties. iD supports this with a separate property `strings.options`
+    // which is an object of value:name pairs. This does not allow ordering of
+    // options like Mapeo supports.
+    // https://github.com/openstreetmap/iD/tree/develop/data/presets#strings
     if (
       Array.isArray(field.options) &&
       field.options.every(opt => typeof opt === 'object')

--- a/src/renderer/components/MapEditor/index.js
+++ b/src/renderer/components/MapEditor/index.js
@@ -399,11 +399,17 @@ function convertPresets (presetsObj) {
       type,
       snake_case: snakeCase
     }
-    if (Array.isArray(field.options)) {
-      fields[fieldId].options = field.options.map(opt => {
-        if (opt && opt.value) return opt.value
-        return opt
+    if (
+      Array.isArray(field.options) &&
+      field.options.every(opt => typeof opt === 'object')
+    ) {
+      const mapeoOptions = field.options
+      const iDStringOptions = {}
+      mapeoOptions.forEach(opt => {
+        iDStringOptions[opt.value] = opt.label
       })
+      delete fields[fieldId].options
+      fields[fieldId].strings = { options: iDStringOptions }
     }
   })
 

--- a/src/renderer/components/MapEditor/index.js
+++ b/src/renderer/components/MapEditor/index.js
@@ -399,6 +399,8 @@ function convertPresets (presetsObj) {
       case 'text':
         if (!field.appearance || field.appearance === 'multiline') {
           type = 'textarea'
+        } else {
+          type = 'text'
         }
         break
       default:

--- a/src/renderer/components/MapEditor/index.js
+++ b/src/renderer/components/MapEditor/index.js
@@ -383,7 +383,7 @@ function convertPresets (presetsObj) {
           typeof field.snake_case === 'boolean' ? field.snake_case : false
         break
       case 'select_multiple':
-        type = 'text'
+        type = 'semiCombo'
         break
       case 'text':
         if (!field.appearance || field.appearance === 'multiline') {


### PR DESCRIPTION
The schema for Mapeo presets and fields differs slightly from iD Editor. This improves the conversion of presets used in Mapeo so that they better appear when viewing monitoring data in the territory view of Mapeo Desktop.

- Fixes fields of type `text` where `appearance=singleline` (was causing crash)
- Uses the iD Editor `semiCombo` type to display select-multiple fields (NB: The resulting field is a semi-colon-separated string, whereas Mapeo expects this to be an array, so this will not work for editing observations in the territory view).
- Uses the correct labels defined in the preset for select fields.