### PR TITLE
feat: Support helperText for fields in iD and improve field display

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "flat": "^5.0.0",
     "fs-write-stream-atomic": "^1.0.10",
     "html-react-parser": "^0.9.1",
-    "id-mapeo": "^3.2.1",
+    "id-mapeo": "^3.3.0",
     "insert-css": "^1.0.0",
     "ky": "^0.14.0",
     "lodash": "^4.17.4",


### PR DESCRIPTION
I made some changes to our fork of iD Editor to better display preset fields in iD Editor. The changes are in https://github.com/digidem/iD-mapeo/pull/12 and include:

- Remove support for tagInfo lookups (this only worked for OSM tags, which we do not generally use, and did not work offline.
- Use the UI space for tagInfo for displaying a new field property helperText which shows additional information to help a user answer a question / fill in the field.
- Remove the option to collapse the "All Fields" section of the preset editor. This was unintuitive and could result in users collapsing it by mistake and not being able to find the fields to fill in.
- Allows labels for fields to span multiple lines
- Removes the "Unknown" defult placeholder, and just displays an empty input box if no placeholder is defined for a field.
- Uses field.label as the label if no translation is available (previously it defaulted to field.id if no translation was defined.
- Ensure dropdowns are attached to the input field, not to the bottom of the helper text.