### PR TITLE
feat: Always add "Notes" field to preset for iD [WIP]

### DIFF
--- a/src/renderer/components/MapEditor/index.js
+++ b/src/renderer/components/MapEditor/index.js
@@ -333,13 +333,19 @@ const fallbackPresets = {
   }
 }
 
-// iD Editor requires that a "name" field is always defined.
 const fallbackFields = {
+  // iD Editor requires that a "name" field is always defined.
   name: {
     key: 'name',
     type: 'localized',
     label: 'Name',
     placeholder: 'Common name (if any)'
+  },
+  // In Mapeo we always have a notes field (we call it "Description")
+  notes: {
+    key: 'notes',
+    type: 'textarea',
+    label: 'Notes'
   }
 }
 
@@ -358,17 +364,23 @@ function convertPresets (presetsObj) {
   // `categoryId`
   Object.keys(presets).forEach(presetId => {
     const preset = presets[presetId]
+    let tags = preset.tags
+    let fields = preset.fields
     if (
-      Object.keys(preset.tags || {}).length === 0 &&
+      Object.keys(tags || {}).length === 0 &&
       // Skip for fallback presets `point`, `line`, `area`, `relation`
       !Object.keys(fallbackPresets).includes(presetId)
     ) {
-      presets[presetId] = {
-        ...preset,
-        tags: {
-          categoryId: presetId
-        }
-      }
+      tags = { categoryId: presetId }
+    }
+    if (!((fields || []).includes('notes'))) {
+      // Add a notes field before other fields, if it doesn't already exist
+      fields = ['notes'].concat(fields || [])
+    }
+    presets[presetId] = {
+      ...preset,
+      tags: tags,
+      fields: fields
     }
   })
 


### PR DESCRIPTION
On Mapeo Mobile (and in observation view) we always display a description / notes field. (the "what is happening here?" text box on mobile). This data is stored under the `notes` tag. Our settings files do not include `notes` as a field for any presets. This PR adds the notes field to all presets, as the field field that displays.

The down side of this is that the notes field will always show, even e.g. for Waorani mapping. Also, it is not currently translated - it always shows "Notes".

Before release:

- @aliya-ryan is it a problem always showing the notes field in the mapping view?
- We need to figure out how to translate this field.