### PR TITLE
Chore: use package lock

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        config: 
+        config:
           - { os: macos-latest, arch: x64, name: macos-latest }
           - { os: ubuntu-latest, arch: x64, name: ubuntu-latest }
           - { os: windows-latest, arch: x64, name: windows-latest }
@@ -26,12 +26,12 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12.4
-          architecture: ${{matrix.config.arch}} 
-      - name: npm install
+          architecture: ${{matrix.config.arch}}
+      - name: npm ci
         run: |
-          npm install
+          npm ci
         env:
-          npm_config_arch: ${{matrix.config.arch}} 
+          npm_config_arch: ${{matrix.config.arch}}
       - name: Lint
         run: |
           npm run lint

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-package-lock=false
+package-lock=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mapeo-desktop",
-  "version": "5.1.0",
+  "version": "5.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,10 @@
     "html-react-parser": "^0.9.1",
     "id-mapeo": "^3.2.1",
     "insert-css": "^1.0.0",
+    "kappa-core": "^4.0.0",
+    "kappa-osm": "^3.0.0",
     "ky": "^0.14.0",
+    "level": "^5.0.0",
     "lodash": "^4.17.4",
     "mapbox-gl": "^1.4.1",
     "mapeo-server": "^17.0.1",
@@ -103,6 +106,7 @@
     "osm-p2p": "^5.1.0",
     "osm-p2p-server": "v6.0.0",
     "pump": "^1.0.3",
+    "random-access-file": "^2.1.0",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
     "react-error-boundary": "^1.2.5",
@@ -118,11 +122,7 @@
     "tar-fs": "^1.16.0",
     "through2": "^2.0.5",
     "utm": "^1.1.1",
-    "yazl": "^2.5.1",
-    "kappa-core": "^4.0.0",
-    "kappa-osm": "^3.0.0",
-    "level": "^5.0.0",
-    "random-access-file": "^2.1.0"
+    "yazl": "^2.5.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.6.0",


### PR DESCRIPTION
I noticed that we had an `.npmrc` file that was turning package-lock off, and we were using `npm install` on Github CI which does not strictly follow package-lock.

This PR turns package-lock on, and uses `npm ci` to install things on CI. We should test that the builds from this PR work before merging.