### PR TITLE
fix: React Storybook now runs again

### DIFF
--- a/.storybook/__mocks__/electron-timber.js
+++ b/.storybook/__mocks__/electron-timber.js
@@ -1,0 +1,1 @@
+module.exports = console.log

--- a/.storybook/__mocks__/node-wifi.js
+++ b/.storybook/__mocks__/node-wifi.js
@@ -1,0 +1,3 @@
+module.exports = () => {
+  throw new Error('Unimplemented')
+}

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -6,7 +6,9 @@ const alias = {
     __dirname,
     '__mocks__/fs-write-stream-atomic.js'
   ),
-  electron: path.resolve(__dirname, '__mocks__/electron.js')
+  electron: path.resolve(__dirname, '__mocks__/electron.js'),
+  'node-wifi': path.resolve(__dirname, '__mocks__/node-wifi.js'),
+  'electron-timber': path.resolve(__dirname, '__mocks__/electron-timber.js')
 }
 
 module.exports = async ({ config }) => {


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Mapeo Crowdin project](https://crowdin.com/project/mapeo-desktop)_
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
### Description

The introduction of `electron-timber` and `node-wifi` packages caused storybook to fail to load.