### PR TITLE
chore(deps): Update @mapeo/core to v8.2.2

### DIFF
--- a/bin/mock.js
+++ b/bin/mock.js
@@ -44,7 +44,7 @@ function main () {
     })
   })
 
-  process.on('SIGINT', function () {
+  process.on('exit', function () {
     debug('shutting down')
     device.shutdown(function () {
       console.log('device finished shut down')
@@ -76,11 +76,6 @@ function createMockDevice (userDataPath, opts) {
   })
   server.on('error', function (err) {
     console.trace(err)
-  })
-
-  server.on('close', function () {
-    console.log('closing mapeo')
-    server.mapeo.api.close()
   })
 
   server.mapeo = mapeo
@@ -203,7 +198,8 @@ function createMockData (count, cb) {
 
 function shutdown (cb) {
   var server = this
-  server.mapeo.api.close(function () {
+  // TODO: decouple server and mapeo core
+  server.mapeo.api.core.close(function () {
     server.close(cb)
   })
 }

--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -223,6 +223,14 @@
     "description": "Button when sync is complete",
     "message": "Complete"
   },
+  "renderer.components.SyncView.SyncButton.disconnected": {
+    "description": "Disconnected",
+    "message": "Disconnected"
+  },
+  "renderer.components.SyncView.SyncButton.finishing": {
+    "description": "Almost done! But progress is inaccurate.",
+    "message": "Finishing…"
+  },
   "renderer.components.SyncView.SyncButton.retry": {
     "description": "Button to retry sync after error",
     "message": "Retry"
@@ -265,13 +273,19 @@
   "renderer.components.SyncView.index.openSyncFileDialog": {
     "message": "Select a database to syncronize"
   },
+  "renderer.components.dialogs.ChangeLanguage.button-cancel": {
+    "message": "Cancel"
+  },
+  "renderer.components.dialogs.ChangeLanguage.button-submit": {
+    "message": "Submit"
+  },
+  "renderer.components.dialogs.ChangeLanguage.dialog-enter-language": {
+    "message": "Choose a language"
+  },
   "renderer.components.dialogs.LatLon.button-submit": {
     "message": "Submit"
   },
   "renderer.components.dialogs.LatLon.dialog-enter-latlon-coordinates": {
     "message": "Enter Coordinates"
-  },
-  "renderer.components.dialogs.ChangeLanguage.dialog-enter-language": {
-    "message": "Choose a Language"
   }
 }

--- a/messages/renderer/es.json
+++ b/messages/renderer/es.json
@@ -223,6 +223,14 @@
     "description": "Button when sync is complete",
     "message": "Completo"
   },
+  "renderer.components.SyncView.SyncButton.disconnected": {
+    "description": "Disconnected",
+    "message": ""
+  },
+  "renderer.components.SyncView.SyncButton.finishing": {
+    "description": "Almost done! But progress is inaccurate.",
+    "message": ""
+  },
   "renderer.components.SyncView.SyncButton.retry": {
     "description": "Button to retry sync after error",
     "message": "Reintentar"
@@ -265,19 +273,19 @@
   "renderer.components.SyncView.index.openSyncFileDialog": {
     "message": "Seleccionar base de datos para sincronizar"
   },
+  "renderer.components.dialogs.ChangeLanguage.button-cancel": {
+    "message": ""
+  },
   "renderer.components.dialogs.ChangeLanguage.button-submit": {
     "message": ""
   },
   "renderer.components.dialogs.ChangeLanguage.dialog-enter-language": {
-    "message": ""
+    "message": "Choose a Language"
   },
   "renderer.components.dialogs.LatLon.button-submit": {
     "message": "Ir"
   },
   "renderer.components.dialogs.LatLon.dialog-enter-latlon-coordinates": {
     "message": "Ingresar coordenadas"
-  },
-  "renderer.components.dialogs.ChangeLanguage.dialog-enter-language": {
-    "message": "Choose a Language"
   }
 }

--- a/messages/renderer/pt.json
+++ b/messages/renderer/pt.json
@@ -223,6 +223,14 @@
     "description": "Button when sync is complete",
     "message": "Concluída"
   },
+  "renderer.components.SyncView.SyncButton.disconnected": {
+    "description": "Disconnected",
+    "message": ""
+  },
+  "renderer.components.SyncView.SyncButton.finishing": {
+    "description": "Almost done! But progress is inaccurate.",
+    "message": ""
+  },
   "renderer.components.SyncView.SyncButton.retry": {
     "description": "Button to retry sync after error",
     "message": "Tentar novamente"
@@ -265,13 +273,19 @@
   "renderer.components.SyncView.index.openSyncFileDialog": {
     "message": "Selecionar base de dados para sincronizar"
   },
+  "renderer.components.dialogs.ChangeLanguage.button-cancel": {
+    "message": ""
+  },
+  "renderer.components.dialogs.ChangeLanguage.button-submit": {
+    "message": ""
+  },
+  "renderer.components.dialogs.ChangeLanguage.dialog-enter-language": {
+    "message": "Escolha idioma"
+  },
   "renderer.components.dialogs.LatLon.button-submit": {
     "message": "Ir"
   },
   "renderer.components.dialogs.LatLon.dialog-enter-latlon-coordinates": {
     "message": "Inserir coordenadas"
-  },
-  "renderer.components.dialogs.ChangeLanguage.dialog-enter-language": {
-    "message": "Escolha idioma"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1678,6 +1678,69 @@
       "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
     },
+    "@mapeo/core": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@mapeo/core/-/core-8.2.4.tgz",
+      "integrity": "sha512-UzQwEnjIrtouuvhdR04Mn+kd8ECRuPPF/STmPRswAlwebTtPm9Wi53ftgQEqMHBJQQHOFf79v6xhQsjLf2FWMA==",
+      "requires": {
+        "blob-store-replication-stream": "^1.3.0",
+        "concat-stream": "^2.0.0",
+        "dat-swarm-defaults": "^1.0.2",
+        "debug": "^4.1.1",
+        "discovery-swarm": "6.0.0",
+        "end-of-stream": "^1.4.1",
+        "gtran-shapefile": "^1.1.3",
+        "handshake-stream": "^3.0.0",
+        "hypercore-crypto": "^1.0.0",
+        "inherits": "^2.0.3",
+        "multifeed": "^4.3.0",
+        "multiplex": "^6.7.0",
+        "osm-p2p-geojson": "^4.0.1",
+        "osm-p2p-syncfile": "^4.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^2.0.1",
+        "randombytes": "^2.0.6",
+        "run-parallel": "^1.1.9",
+        "shp-write": "github:digidem/shp-write",
+        "statuses": "^1.5.0",
+        "through2": "^3.0.0"
+      },
+      "dependencies": {
+        "multifeed": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/multifeed/-/multifeed-4.3.0.tgz",
+          "integrity": "sha512-7RLBHilfBA9FTdTw98YbFv/UEg/44dIEefLRn/ALDnB1MMjB7gxGcgXqE01AH63oW8/uS30mndoFCBx/GyC7fg==",
+          "requires": {
+            "debug": "^4.1.0",
+            "hypercore-protocol": "^6.8.0",
+            "inherits": "^2.0.3",
+            "mutexify": "^1.2.0",
+            "once": "^1.4.0",
+            "random-access-file": "^2.0.1",
+            "random-access-memory": "^3.1.1",
+            "through2": "^3.0.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "through2": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+          "requires": {
+            "inherits": "^2.0.4",
+            "readable-stream": "2 || 3"
+          }
+        }
+      }
+    },
     "@mapeo/settings": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@mapeo/settings/-/settings-2.1.1.tgz",
@@ -2780,8 +2843,7 @@
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-      "dev": true
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
     },
     "@types/geojson": {
       "version": "7946.0.7",
@@ -2792,7 +2854,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
       "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
-      "dev": true,
       "requires": {
         "@types/events": "*",
         "@types/minimatch": "*",
@@ -2828,14 +2889,12 @@
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-      "dev": true
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
-      "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==",
-      "dev": true
+      "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ=="
     },
     "@types/npmlog": {
       "version": "4.1.2",
@@ -5388,9 +5447,9 @@
       "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
     },
     "chrome-dgram": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/chrome-dgram/-/chrome-dgram-3.0.4.tgz",
-      "integrity": "sha512-G8rOANSvSRC4hGny/K/ec1gXtNuZGzryFeoev49u0J4g/qws7H25vMKQlbD9izuedFVHwXFTdKQG62Tf/7Cmwg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/chrome-dgram/-/chrome-dgram-3.0.5.tgz",
+      "integrity": "sha512-RcCR5Kpn+F7VGmtL3ex78ltB+cuuSTZdGBa4j3fQwUqz/90uOKd5t+WmnJp+QNv017oaHzn5GoMv1mCoRTmehQ==",
       "requires": {
         "inherits": "^2.0.1",
         "run-series": "^1.1.2"
@@ -5405,9 +5464,9 @@
       }
     },
     "chrome-net": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/chrome-net/-/chrome-net-3.3.3.tgz",
-      "integrity": "sha512-11jL8+Ogna8M5TEdyalE8IG6cpaFEU3YcaxAj3YjZKjRM/PeT70pZbrUY+xoGwqiEJZwJE4Td2CvGxUvS9ytKQ==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/chrome-net/-/chrome-net-3.3.4.tgz",
+      "integrity": "sha512-Jzy2EnzmE+ligqIZUsmWnck9RBXLuUy6CaKyuNMtowFG3ZvLt8d+WBJCTPEludV0DHpIKjAOlwjFmTaEdfdWCw==",
       "requires": {
         "inherits": "^2.0.1"
       }
@@ -12640,9 +12699,9 @@
       "dev": true
     },
     "indexed-tarball": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/indexed-tarball/-/indexed-tarball-3.1.5.tgz",
-      "integrity": "sha512-3ocbaaGnBQgDUi9Go2u2Z9bm8RqUJivOGICW8kURZuMGPcxSPAKXfdLkeUlz4IxgChsMnOL4klpJXpt/HMVnDg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/indexed-tarball/-/indexed-tarball-3.1.6.tgz",
+      "integrity": "sha512-Ukv+af30t1KQE7Pz+e25K2W5bbbAFu1VGeMOJax539rzsbIZc4+Bb8UCgsozk/0OVCXQ3gJ5A/B67PRuYc0xMA==",
       "requires": {
         "pump": "^3.0.0",
         "read-only-stream": "^2.0.0",
@@ -13136,6 +13195,11 @@
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true
+    },
+    "is-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-options/-/is-options-1.0.1.tgz",
+      "integrity": "sha512-2Xj8sA0zDrAcaoWfBiNmc6VPWAgKDpim0T3J9Djq7vbm1UjwbUWzeuLu/FwC46g3cBbAn0E5R0xwVtOobM6Xxg=="
     },
     "is-path-inside": {
       "version": "1.0.1",
@@ -14850,11 +14914,11 @@
       }
     },
     "mapeo-server": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/mapeo-server/-/mapeo-server-17.0.1.tgz",
-      "integrity": "sha512-wToPn++uIVIhYWxflKq1e5437W/Jm2CFsfGLVF/ByRz4jSD3HXof6mjb/AHGS4G7HbZQO3HCHh11sLJgqHK9yw==",
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/mapeo-server/-/mapeo-server-17.0.4.tgz",
+      "integrity": "sha512-393KHa0M+DhSf/UWCILxksY6ifNx+6mOG2aHFE6H9YPSr60VZknoJ+pnU8ojyLxme6OMYcKiMrvUutG0jCw2EA==",
       "requires": {
-        "@mapeo/core": "^8.1.2",
+        "@mapeo/core": "^8.2.4",
         "asar": "^2.0.1",
         "body": "^5.1.0",
         "debounce": "^1.2.0",
@@ -14868,38 +14932,12 @@
         "xtend": "^4.0.1"
       },
       "dependencies": {
-        "@mapeo/core": {
-          "version": "8.1.3",
-          "resolved": "https://registry.npmjs.org/@mapeo/core/-/core-8.1.3.tgz",
-          "integrity": "sha512-/IciehuILGRFI7Mn4pZdeWL4nijP0sec/WGFIEAYPAEDIuHDBOgGQLZrlfnao0jZ/rR5suP2GOpxvxmajiIJpA==",
-          "requires": {
-            "blob-store-replication-stream": "^1.3.0",
-            "concat-stream": "^2.0.0",
-            "dat-swarm-defaults": "^1.0.2",
-            "debug": "^4.1.1",
-            "discovery-swarm": "6.0.0",
-            "end-of-stream": "^1.4.1",
-            "gtran-shapefile": "^1.1.3",
-            "handshake-stream": "^3.0.0",
-            "hypercore-crypto": "^1.0.0",
-            "inherits": "^2.0.3",
-            "multiplex": "^6.7.0",
-            "osm-p2p-geojson": "^4.0.1",
-            "osm-p2p-syncfile": "^4.1.0",
-            "pump": "^3.0.0",
-            "pumpify": "^2.0.1",
-            "randombytes": "^2.0.6",
-            "run-parallel": "^1.1.9",
-            "shp-write": "github:digidem/shp-write",
-            "statuses": "^1.5.0",
-            "through2": "^3.0.0"
-          }
-        },
         "asar": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/asar/-/asar-2.0.3.tgz",
-          "integrity": "sha512-QdHKO+HOYVtE4B/M3up3i4LSJeJgsa2CTVBrjBf9GgLUPGGUFZowcdJ5yE4gOJuRAHNdqB9JFeRfFfaOu5x8Rw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/asar/-/asar-2.1.0.tgz",
+          "integrity": "sha512-d2Ovma+bfqNpvBzY/KU8oPY67ZworixTpkjSx0PCXnQi67c2cXmssaTxpFDUM0ttopXoGx/KRxNg/GDThYbXQA==",
           "requires": {
+            "@types/glob": "^7.1.1",
             "chromium-pickle-js": "^0.2.0",
             "commander": "^2.20.0",
             "cuint": "^0.2.2",
@@ -14910,9 +14948,9 @@
           }
         },
         "ecstatic": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-4.1.2.tgz",
-          "integrity": "sha512-lnrAOpU2f7Ra8dm1pW0D1ucyUxQIEk8RjFrvROg1YqCV0ueVu9hzgiSEbSyROqXDDiHREdqC4w3AwOTb23P4UQ==",
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-4.1.4.tgz",
+          "integrity": "sha512-8E4ZLK4uRuB9pwywGpy/B9vcz4gCp6IY7u4cMbeCINr/fjb1v+0wf0Ae2XlfSnG8xZYnE4uaJBjFkYI0bqcIdw==",
           "requires": {
             "charset": "^1.0.1",
             "he": "^1.1.1",
@@ -14922,41 +14960,10 @@
             "url-join": "^4.0.0"
           }
         },
-        "file-saver": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.0.tgz",
-          "integrity": "sha512-cYM1ic5DAkg25pHKgi5f10ziAM7RJU37gaH1XQlyNDrtUnzhC/dfoV9zf2OmF0RMKi42jG5B0JWBnPQqyj/G6g=="
-        },
         "mime": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
-        },
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
-        "shp-write": {
-          "version": "github:digidem/shp-write#02b37559e61f8951dc238ed22de80e4e2aa6cf0f",
-          "from": "github:digidem/shp-write",
-          "requires": {
-            "dbf": "0.1.4",
-            "file-saver": "2.0.0",
-            "jszip": "3.1.5"
-          }
-        },
-        "through2": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
-          "requires": {
-            "readable-stream": "2 || 3"
-          }
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
         },
         "url-join": {
           "version": "4.0.1",
@@ -15583,9 +15590,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multicast-dns": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.0.tgz",
-      "integrity": "sha512-Tu2QORGOFANB124NWQ/JTRhMf/ODouVLEuvu5Dz8YWEU55zQgRgFGnBHfIh5PbfNDAuaRl7yLB+pgWhSqVxi2Q==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.2.tgz",
+      "integrity": "sha512-XqSMeO8EWV/nOXOpPV8ztIpNweVfE1dSpz6SQvDPp71HD74lMXjt4m/mWB1YBMG0kHtOodxRWc5WOb/UNN1A5g==",
       "requires": {
         "dns-packet": "^4.0.0",
         "thunky": "^1.0.2"
@@ -20651,9 +20658,9 @@
       }
     },
     "osm-p2p-syncfile": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/osm-p2p-syncfile/-/osm-p2p-syncfile-4.1.1.tgz",
-      "integrity": "sha512-Bvx1dkXNFzsEe8snjHSqSynoItm30bAWmJs/OoicGdbq2VU3hD4VWv/dLbNyuiGTpC9qOKs6dQRpLiXhU082+w==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/osm-p2p-syncfile/-/osm-p2p-syncfile-4.1.2.tgz",
+      "integrity": "sha512-JE1aK+pDUWK4QfbsRKF+4whnQA29nLMqA/zhnhdBBDRgF6zM2r5m4AHGwIcmSPojO4kJLxNkvvu16essnprv5A==",
       "requires": {
         "blob-store-replication-stream": "^1.3.3",
         "debug": "^3.1.0",
@@ -20661,7 +20668,7 @@
         "indexed-tarball": "^3.1.3",
         "indexed-tarball-blob-store": "^1.1.0",
         "mkdirp": "^0.5.1",
-        "multifeed": "4.1.10",
+        "multifeed": "^4.2.2",
         "once": "^1.4.0",
         "osm-p2p": "^5.0.0",
         "readdirp": "^2.1.0",
@@ -20677,6 +20684,40 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
+          }
+        },
+        "multifeed": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/multifeed/-/multifeed-4.3.0.tgz",
+          "integrity": "sha512-7RLBHilfBA9FTdTw98YbFv/UEg/44dIEefLRn/ALDnB1MMjB7gxGcgXqE01AH63oW8/uS30mndoFCBx/GyC7fg==",
+          "requires": {
+            "debug": "^4.1.0",
+            "hypercore-protocol": "^6.8.0",
+            "inherits": "^2.0.3",
+            "mutexify": "^1.2.0",
+            "once": "^1.4.0",
+            "random-access-file": "^2.0.1",
+            "random-access-memory": "^3.1.1",
+            "through2": "^3.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "through2": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+              "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+              "requires": {
+                "inherits": "^2.0.4",
+                "readable-stream": "2 || 3"
+              }
+            }
           }
         },
         "rimraf": {
@@ -22328,6 +22369,16 @@
       "integrity": "sha512-AE0Z1ywR5gIkzACMC1lCsR6LP8g4ynNm7oYWYdKPSSU6Y3H+mGDJxBqfcV9B9KstfHNemhfX3nYmx99ZC9f/yg==",
       "requires": {
         "mkdirp": "^0.5.1",
+        "random-access-storage": "^1.1.1"
+      }
+    },
+    "random-access-memory": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/random-access-memory/-/random-access-memory-3.1.1.tgz",
+      "integrity": "sha512-Qy1MliJDozZ1A6Hx3UbEnm8PPCfkiG/8CArbnhrxXMx1YRJPWipgPTB9qyhn4Z7WlLvCEqPb6Bd98OayyVuwrA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-options": "^1.0.1",
         "random-access-storage": "^1.1.1"
       }
     },
@@ -24293,8 +24344,8 @@
       }
     },
     "shp-write": {
-      "version": "0.3.2",
-      "resolved": "github:digidem/shp-write#02b37559e61f8951dc238ed22de80e4e2aa6cf0f",
+      "version": "github:digidem/shp-write#02b37559e61f8951dc238ed22de80e4e2aa6cf0f",
+      "from": "github:digidem/shp-write",
       "requires": {
         "dbf": "0.1.4",
         "file-saver": "2.0.0",
@@ -26371,9 +26422,9 @@
       "dev": true
     },
     "timeout-refresh": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/timeout-refresh/-/timeout-refresh-1.0.1.tgz",
-      "integrity": "sha512-bW5oSShdwFCN9K7RpB5dkq5bqNlGt8Lwbfxr8vprysk8hDiK5yy7Mgf2Qlz2ssE0gfQfoYhk4VLY9Hhsnr9Ulw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/timeout-refresh/-/timeout-refresh-1.0.2.tgz",
+      "integrity": "sha512-lsO23gD/EeW53AvEoTOleUFqTIapZTu5NPzD6ndUGs0+G1IuN0+hu2kT6I3AmNX2fiOrcC6umtzMEv1XQmajgQ==",
       "optional": true
     },
     "timers-browserify": {
@@ -27314,9 +27365,9 @@
       "integrity": "sha512-rJIv6i1u86OVy91Burh/6oRFfE8zOCd6Unc8fvA0N7fjQT43ogqhVeUp5NByaZPe278QyiA5wMMEaAU9Jx6QRA=="
     },
     "utp-native": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/utp-native/-/utp-native-2.1.7.tgz",
-      "integrity": "sha512-PQmXCdZOkmADtIqmhoiFEIdNlvkPouO8ktXqThFDBAt850B752bjQMF5KAJeMBJ5gzuI70ZiP9Qsr9mwCwzSyg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/utp-native/-/utp-native-2.2.0.tgz",
+      "integrity": "sha512-Yx7O/vbgBNnsqEdIrVzST/cF8Tj/JaLUeQEdRbCSKDpSnHEf+kioD0Xspau2OAI/jkZaAxc67/HqLc03Ykf4mQ==",
       "optional": true,
       "requires": {
         "napi-macros": "^2.0.0",
@@ -27327,9 +27378,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "optional": true,
           "requires": {
             "inherits": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "level": "^5.0.0",
     "lodash": "^4.17.4",
     "mapbox-gl": "^1.4.1",
-    "mapeo-server": "^17.0.1",
+    "mapeo-server": "^17.0.4",
     "mapeo-styles": "^3.0.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",

--- a/src/background/mapeo.js
+++ b/src/background/mapeo.js
@@ -12,8 +12,8 @@ const logger = require('../logger')
 const TileImporter = require('./tile-importer')
 const installStatsIndex = require('./osm-stats')
 
-// This is an RPC wrapper for all the things related to mapeo/core
-// much of this code probably could instead be in mapeo/core
+// This is an RPC wrapper for all the things related to mapeo core
+// TODO: much of this code should instead be in mapeo core
 
 class MapeoRPC {
   constructor ({ datadir, userDataPath, ipcSend }) {
@@ -255,6 +255,7 @@ class MapeoRPC {
       const { connection, ...rest } = peer
       return rest
     })
+    logger.debug('sending peer update', peers)
     this.ipcSend('peer-update', peers)
   }
 }

--- a/src/renderer/components/SyncView/SyncButton.js
+++ b/src/renderer/components/SyncView/SyncButton.js
@@ -16,7 +16,11 @@ const m = defineMessages({
   // Button when sync is complete
   complete: 'Complete',
   // Button to retry sync after error
-  retry: 'Retry'
+  retry: 'Retry',
+  // Disconnected
+  disconnected: 'Disconnected',
+  // Almost done! But progress is inaccurate.
+  finishing: 'Finishing…'
 })
 
 const SyncIcon = props => <FontAwesomeIcon icon={faBolt} {...props} />
@@ -73,29 +77,34 @@ const StyledButton = ({ className, ...props }) => {
   )
 }
 
-const SyncButton = ({ progress, onClick, variant = 'ready' }) => {
+const SyncButton = ({ progress, connected, onClick, variant = 'ready' }) => {
   const classes = useStyles()
   const { formatMessage: t } = useIntl()
   switch (variant) {
     case 'ready':
     case 'error':
       return (
-        <StyledButton onClick={onClick}>
-          {variant === 'ready' ? t(m.sync) : t(m.retry)}
+        <StyledButton disabled={!connected} onClick={onClick}>
+          {!connected ? t(m.disconnected)
+            : variant === 'ready' ? t(m.sync) : t(m.retry)}
           <SyncIcon className={classes.icon} />
         </StyledButton>
       )
     case 'progress':
       return (
         <StyledButton disabled onClick={onClick} className={classes.progress}>
-          {progress ? (progress * 100).toFixed(0) + '%' : t(m.starting)}
+          {!progress
+            ? t(m.starting)
+            : progress === 1
+              ? t(m.finishing)
+              : (progress * 100).toFixed(0) + '%' }
           <ProgressIcon progress={progress} className={classes.icon} />
         </StyledButton>
       )
 
     case 'complete':
       return (
-        <StyledButton onClick={onClick}>
+        <StyledButton disabled={!connected} onClick={onClick}>
           {t(m.complete)}
           <DoneIcon className={classes.icon} />
         </StyledButton>

--- a/src/renderer/components/SyncView/SyncTarget.js
+++ b/src/renderer/components/SyncView/SyncTarget.js
@@ -28,6 +28,8 @@ const SyncTarget = ({
   name = 'Android Phone',
   // See above peerStatus
   status,
+  // If connected
+  connected,
   // Sync progress object, with props `percent`, `mediaSofar`, `mediaTotal`,
   // `dbSofar`, `dbTotal`
   progress,
@@ -88,6 +90,7 @@ const SyncTarget = ({
           )}
         </div>
         <SyncButton
+          connected={connected}
           onClick={onClick}
           variant={status}
           progress={progress && progress.percent}


### PR DESCRIPTION
This fixes underlying sync state bugs by integrating updates from Mapeo Core that were finished in May by @noffle.

This will need to be a coordinated [release with Mapeo Mobile v5 ](https://github.com/digidem/mapeo-mobile/pull/358)

Depends upon https://github.com/digidem/mapeo-core/pull/94

Here's a demo of me trying to break it! 

https://www.dropbox.com/s/udeevnpniw1r7pn/fix-that-sync-bug.mp4?dl=0

Open question to @gmaclennan  -- do we want to abstract this sync state client logic into a `@mapeo/client` module to re-use in mobile? Do we want to do this now or later? Ideally the only difference btwn mobile & desktop is the user interface/presentation layer, not the state logic 