### PR TITLE
fix: After a sync error, keep the device name visible

### DIFF
--- a/src/renderer/components/SyncView/SyncTarget.js
+++ b/src/renderer/components/SyncView/SyncTarget.js
@@ -61,7 +61,7 @@ const SyncTarget = ({
             <PhoneIcon fontSize='inherit' className={cx.icon} />
           )}
           <Typography variant='h5' component='h2'>
-            {status === 'error' ? t(m.errorMsg) : name}
+            {name}
           </Typography>
           {status === 'error' ? (
             <Typography className={cx.errorDetail} align='center'>


### PR DESCRIPTION
If a device has an error, it will now still show the device name