### PR TITLE
chore: Remove un-used architecture option for actions/setup-node

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: Node CD
 
-on: 
+on:
   push:
     tags:
       - '*'
@@ -32,7 +32,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12.4
-          architecture: ${{matrix.config.arch}}
       - name: npm ci
         run: |
           npm ci


### PR DESCRIPTION
This just removes the warning from Github actions because this is not a valid option for actions/setup-node. See also https://github.com/actions/setup-node/pull/42