### PR TITLE
chore: Remove unnecessary matrix config from github action CD

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: Node CD
 
-on: 
+on:
   push:
     tags:
       - '*'
@@ -15,10 +15,10 @@ jobs:
     strategy:
       matrix:
         config:
-          - { os: macos-latest, arch: x64, name: macos-latest }
-          - { os: ubuntu-latest, arch: x64, name: ubuntu-latest, needs: [ macos-latest] }
-          - { os: windows-latest, arch: x64, name: windows-latest, needs: [ ubuntu-latest ]  }
-          - { os: windows-latest, arch: ia32, name: windows-latest-32,needs: [ windows-latest] }
+          - { os: macos-latest, arch: x64 }
+          - { os: ubuntu-latest, arch: x64 }
+          - { os: windows-latest, arch: x64 }
+          - { os: windows-latest, arch: ia32 }
 
     steps:
       - name: Context
@@ -67,5 +67,5 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: ${{ matrix.config.name }}
+          name: '${{ matrix.config.os }}-${{ matrix.config.arch }}'
           path: dist


### PR DESCRIPTION
The Github actions config `jobs.build.strategy.matrix.config` had some extra fields that are not needed. This seems to be related to the required checks on each PR. This PR removes config variables in the matrix that are not needed. It shouldn't change anything, just need to check that the artifacts names are correct after the CI runs.