### PR TITLE
fix: Fix icon layout in dmg for MacOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,14 +241,14 @@
       "title": "${productName} v${version}",
       "contents": [
         {
-          "x": 448,
-          "y": 200,
+          "x": 410,
+          "y": 220,
           "type": "link",
           "path": "/Applications"
         },
         {
-          "x": 220,
-          "y": 200,
+          "x": 130,
+          "y": 220,
           "type": "file"
         }
       ]


### PR DESCRIPTION
Fixes the layout of icons in the DMG installer for MacOS. Was this:

<img width="540" alt="image" src="https://user-images.githubusercontent.com/290457/90429410-94e99c00-e0bd-11ea-8038-6e106c8749db.png">

After:

<img width="540" alt="image" src="https://user-images.githubusercontent.com/290457/90434414-43dda600-e0c5-11ea-8419-46223be6bbfa.png">

