### PR TITLE
fix: Mapeo config directory should be removable

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const mkdirp = require('mkdirp')
 const series = require('run-series')
 const styles = require('mapeo-styles')
 const rabbit = require('electron-rabbit')
+const chmod = require('chela').mod
 
 const app = electron.app
 const BrowserWindow = electron.BrowserWindow
@@ -194,9 +195,19 @@ function initDirectories (done) {
   styles.unpackIfNew(userDataPath, function (err, newSettings) {
     if (err) logger.error('[ERROR] while unpacking styles:', err)
     var fallbackSettingsLocation = path.join(userDataPath, 'presets', styles.FALLBACK_DIR_NAME)
-    if (newSettings) userConfig.copyFallbackSettings(fallbackSettingsLocation, done)
-    else done()
+    if (newSettings) userConfig.copyFallbackSettings(fallbackSettingsLocation, cleanupPermissions)
+    else cleanupPermissions()
   })
+
+  function cleanupPermissions () {
+    chmod(path.join(userDataPath, 'presets'), '0777', (err) => {
+      if (err) logger.error('Failed to execute chmod on presets', err)
+      chmod(path.join(userDataPath, 'styles'), '0777', (err) => {
+        if (err) logger.error('Failed to execute chmod on styles', err)
+        done()
+      })
+    })
+  }
 }
 
 function createServers (done) {

--- a/index.js
+++ b/index.js
@@ -200,9 +200,9 @@ function initDirectories (done) {
   })
 
   function cleanupPermissions () {
-    chmod(path.join(userDataPath, 'presets'), '0777', (err) => {
+    chmod(path.join(userDataPath, 'presets'), '0700', (err) => {
       if (err) logger.error('Failed to execute chmod on presets', err)
-      chmod(path.join(userDataPath, 'styles'), '0777', (err) => {
+      chmod(path.join(userDataPath, 'styles'), '0700', (err) => {
         if (err) logger.error('Failed to execute chmod on styles', err)
         done()
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -6226,6 +6226,22 @@
       "resolved": "https://registry.npmjs.org/charset/-/charset-1.0.1.tgz",
       "integrity": "sha512-6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg=="
     },
+    "chela": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chela/-/chela-0.1.0.tgz",
+      "integrity": "sha512-RFXcD30qG2c7VINeuEu/Y6TdyWwAq7Mw0NrRkYbzM4uIIbzzSh6x4ueruSf0cOMaHNl8OzFdS6ynyfOD8bz4DA==",
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "uid-number": "0.0.5"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+        }
+      }
+    },
     "chokidar": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -28132,6 +28148,11 @@
           "optional": true
         }
       }
+    },
+    "uid-number": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
+      "integrity": "sha1-Wj2yPvXb1VuB/ODsmirG/M3ruB4="
     },
     "uint64be": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "bugsnag-build-reporter": "^1.0.3",
     "bugsnag-sourcemaps": "^1.3.0",
     "capture-exit": "^2.0.0",
+    "chela": "^0.1.0",
     "clsx": "^1.0.4",
     "compare-versions": "^3.6.0",
     "conf": "^6.2.4",


### PR DESCRIPTION
You'd get `EPERM` permissions errors if you tried to remove the Mapeo config directory using `rm -rf ~/.config/Mapeo`