### PR TITLE
fix: Only save the language to config when changed manually. Fixes #400

### DIFF
--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -81,6 +81,7 @@ module.exports = function (ipcSend) {
 
   ipcMain.on('set-locale', function (ev, locale) {
     app.translations = i18n.setLocale(locale)
+    i18n.save()
   })
 
   ipcMain.on('get-locale', function (ev) {


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Mapeo Crowdin project](https://crowdin.com/project/mapeo-desktop)_
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] I have walked through the [QA Manual Testing
  Script](https://github.com/digidem/mapeo-desktop/blob/master/docs/testing.md) and updated it if necessary.
- [NA] If my changes depend upon an update to a dependency, I have updated the package-lock.json file using `npm install --package-lock`
- [x] My changes have been tested with the [mobile app](https://github.com/digidem/mapeo-mobile/releases). 
- [x] My changes are ready to be shipped to users on Windows, Mac, and Linux

### Description

Mapeo was saving the system locale to the config always on startup, so if you change system languages and reopened Mapeo it wouldn't also change system languages.

This now only persists the change in language if the user explicitly requests to change the language through the User Interface.