### PR TITLE
chore: move flow types into mapeo-schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21579,9 +21579,9 @@
       "integrity": "sha512-W2/E/3zx5xB/6HEr8X+pkqJR1GOp0v1MYN7mGWsHB4kqlVFCOL2zKy+hO1gVDLjwlKSa4l1QWHNX3RnseC3Q4w=="
     },
     "mapeo-schema": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/mapeo-schema/-/mapeo-schema-1.10.1.tgz",
-      "integrity": "sha512-L3bUa6Tqp1g1qbZIWyXXA5MUi9+0roMH2bBDMfk4bTPuTrWYp1sp7Sss7qDgK/jASC7wzJ7mU98yERygSVik+g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mapeo-schema/-/mapeo-schema-2.0.0.tgz",
+      "integrity": "sha512-Aw/ugR0YXSGoCyQEePvjhw1Gb8WSG4tNoUs9HO7OGZ5ICP0H3EdBoJnhYsJuLqmHkhbhl80QRoqdzKgGLmYjrQ==",
       "requires": {
         "ajv": "^6.10.0"
       }
@@ -30921,6 +30921,14 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
           "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+        },
+        "mapeo-schema": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/mapeo-schema/-/mapeo-schema-1.10.1.tgz",
+          "integrity": "sha512-L3bUa6Tqp1g1qbZIWyXXA5MUi9+0roMH2bBDMfk4bTPuTrWYp1sp7Sss7qDgK/jASC7wzJ7mU98yERygSVik+g==",
+          "requires": {
+            "ajv": "^6.10.0"
+          }
         },
         "object-path-immutable": {
           "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "mapbox-gl": "^1.4.1",
     "mapbox-map-image-stream": "^2.1.1",
     "mapeo-entity-filter": "^2.0.0",
-    "mapeo-schema": "^1.10.1",
+    "mapeo-schema": "^2.0.0",
     "mapeo-server": "^17.0.6",
     "mapeo-styles": "^3.0.2",
     "mime": "^2.4.6",

--- a/src/renderer/components/MapFilter/ViewWrapper.js
+++ b/src/renderer/components/MapFilter/ViewWrapper.js
@@ -87,6 +87,7 @@ const WrappedMapView = ({
       const preset = getPreset(observation, presets)
       const defaultPreset = defaultGetPreset(observation, stats)
       if (!preset) return defaultPreset
+      // $FlowFixMe - this checks out, seems to be a flow bug, it cannot understand that additionalFields is overwritten
       return {
         ...preset,
         additionalFields: defaultPreset.additionalFields.filter(

--- a/src/renderer/components/MapFilter/types.js
+++ b/src/renderer/components/MapFilter/types.js
@@ -1,7 +1,17 @@
 // @flow
 import * as React from 'react'
 import * as valueTypes from './constants/value_types'
-import type { Observation, Preset } from 'mapeo-schema'
+import type {
+  Observation,
+  Preset,
+  TextField,
+  NumberField,
+  DateField,
+  SelectOneField,
+  SelectMultipleField,
+  LinkField,
+  DateTimeField
+} from 'mapeo-schema'
 // import type { Properties as CSSProperties } from 'csstype'
 
 import type {
@@ -10,6 +20,20 @@ import type {
   Point2D,
   Point3D
 } from 'flow-geojson'
+
+export type {
+  Key,
+  TextField,
+  NumberField,
+  DateField,
+  SelectOneField,
+  SelectMultipleField,
+  LinkField,
+  SelectableFieldValue,
+  LabeledSelectOption,
+  SelectOptions,
+  DateTimeField
+} from 'mapeo-schema'
 
 /**
  * Observation Attachment
@@ -156,92 +180,6 @@ export type Coordinates = {
   speed?: number,
   latitude: number,
   accuracy?: number
-}
-
-export type Key = string | Array<string | number>
-
-type BaseField = {|
-  // A unique id used to reference the field from presets
-  id: string,
-  // They key in a tags object that this field applies to. For nested
-  // properties, key can be an array e.g. for tags = { foo: { bar: 1 } } the key
-  // is ['foo', 'bar']
-  key: Key,
-  label?: string,
-  // Displayed as a placeholder or hint for the field: use for additional
-  // context or example responses for the user
-  placeholder?: string,
-  // If a field definition contains the property "universal": true, this field will appear in the "Add Field" list for all presets
-  universal?: boolean,
-  // Displayed, but cannot be edited
-  readonly?: boolean
-|}
-
-// type FieldType =
-//   | 'text'
-//   | 'number'
-//   | 'select_one'
-//   | 'select_multiple'
-//   | 'date'
-//   | 'datetime'
-
-export type TextField = {
-  ...BaseField,
-  type: 'text' | 'textarea' | 'localized',
-  appearance?: 'singleline' | 'multiline',
-  // Spaces are replaced with underscores
-  snake_case?: boolean
-}
-
-export type LinkField = {
-  ...BaseField,
-  type: 'link'
-}
-
-export type NumberField = {
-  ...BaseField,
-  type: 'number',
-  min_value?: number,
-  max_value?: number
-}
-
-export type SelectableFieldValue = number | string | boolean | null
-
-export type LabeledSelectOption = {|
-  value: SelectableFieldValue,
-  label: string
-|}
-
-export type SelectOptions = Array<SelectableFieldValue | LabeledSelectOption>
-
-export type SelectOneField = {
-  ...BaseField,
-  type: 'select_one',
-  options: SelectOptions,
-  // User can enter their own reponse if not on the list (defaults to true on
-  // desktop, false on mobile)
-  other?: boolean,
-  // Spaces are replaced with underscores
-  snake_case?: boolean
-}
-
-export type SelectMultipleField = {
-  ...$Exact<SelectOneField>,
-  type: 'select_multiple'
-}
-
-export type DateField = {
-  ...BaseField,
-  type: 'date',
-  min_value?: string,
-  max_value?: string
-}
-
-export type DateTimeField = {
-  ...BaseField,
-  type: 'datetime',
-  min_value?: string,
-  max_value?: string
 }
 
 export type Field =


### PR DESCRIPTION
`mapeo-schema` used to generate flow types from JSON schema. Mapeo Desktop defined more strict types manually. `mapeo-schema@2` includes those manually defined types, and this PR switches Mapeo Desktop to use the types from mapeo-schema.