### PR TITLE
fix: Fix pdf report image wrapping

### DIFF
--- a/fixtures/observations.json
+++ b/fixtures/observations.json
@@ -8,6 +8,22 @@
       {
         "id": "2fb09847.jpg",
         "type": "image/jpg"
+      },
+      {
+        "id": "611e97dd.jpg",
+        "type": "image/jpg"
+      },
+      {
+        "id": "9434dfaf.jpg",
+        "type": "image/jpg"
+      },
+      {
+        "id": "af87b30b.jpg",
+        "type": "image/jpg"
+      },
+      {
+        "id": "4a89383c.jpg",
+        "type": "image/jpg"
       }
     ],
     "tags": {

--- a/src/renderer/components/MapFilter/ReportView/PDFReport.js
+++ b/src/renderer/components/MapFilter/ReportView/PDFReport.js
@@ -216,12 +216,11 @@ function ObservationRHS ({ observationView }) {
   return (
     <View style={styles.columnRight}>
       {imageSrc ? (
-        <View style={styles.imageWrapper}>
+        <View style={styles.imageWrapper} wrap={false}>
           <Image
             src={imageSrc}
             key={'minimap-' + observationView.id}
             style={styles.image}
-            wrap={false}
             cache={true}
           />
           <View style={styles.marker} />
@@ -229,12 +228,11 @@ function ObservationRHS ({ observationView }) {
       ) : null}
 
       {observationView.mediaItems.map((src, i) => (
-        <View key={i} style={styles.imageWrapper}>
+        <View key={i} style={styles.imageWrapper} wrap={false}>
           <Image
             cache={true}
             src={src}
             style={styles.image}
-            wrap={false}
           />
         </View>
       ))}


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Mapeo Crowdin project](https://crowdin.com/project/mapeo-desktop)_
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [ ] I have walked through the [QA Manual Testing
  Script](https://github.com/digidem/mapeo-desktop/blob/master/docs/QA.md) and updated it if necessary.
- [x] If my changes depend upon an update to a dependency, I have updated the package-lock.json file using `npm install --package-lock`
- [ ] My changes have been tested with the [mobile app](https://github.com/digidem/mapeo-mobile/releases). 
- [ ] My changes are ready to be shipped to users on Windows, Mac, and Linux using the production version of the application built with electron-builder.

### Description

There was a bug with how images wrap across page boundaries in PDF reports. If an image could not completely fit on the page, the image is correctly shown on the next page, but the image border was wrapped across the page, leaving an empty box, see:

<img width="921" alt="image" src="https://user-images.githubusercontent.com/290457/95317281-dd872f80-088c-11eb-9dbd-23898758cd60.png">

This PR fixes wrapping to ensure that the image container (the border) and the image both move onto the next page together.

I also added some extra images to the first observation fixture, and visually checked the fix using `npm run storybook` and viewing the page wrapping before and after to confirm that images wrap correctly.

@jencastrodoesstuff this should fix #433.