### PR TITLE
fix: Fallback to exporting preview-sized images if originals are missing

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -473,6 +473,22 @@
   "renderer.components.dialogs.LatLon.dialog-enter-latlon-coordinates": {
     "message": "Enter Coordinates"
   },
+  "renderer.create-zip.errorsFilename": {
+    "description": "File name for file with information about export errors",
+    "message": "Export Errors"
+  },
+  "renderer.create-zip.errorsMsg": {
+    "description": "Error message stored in text file in export if there were errors during export",
+    "message": "There was an error trying to export these files, so they are missing from this export:"
+  },
+  "renderer.create-zip.missingOriginalsFilename": {
+    "description": "File name for file with information about missing originals in export",
+    "message": "Missing Originals"
+  },
+  "renderer.create-zip.missingOriginalsMsg": {
+    "description": "Message stored in text file in export if originals are missing. The message is followed by a list of filenames with missing originals",
+    "message": "The original size of these files could not be found, only preview size (1,200 pixel) images are included. This can happen because the phone that took the photos has only synced to other phones, and not directly to Mapeo Desktop. To try fixing this, find the phone that took the photos and sync it with Mapeo Desktop before exporting again."
+  },
   "screens.Observation.ObservationView.noAnswer": {
     "description": "Placeholder text for fields on an observation which are not answered",
     "message": "No answer"

--- a/src/renderer/components/MapFilter/DataExportDialog.js
+++ b/src/renderer/components/MapFilter/DataExportDialog.js
@@ -149,10 +149,19 @@ const ExportDialogContent = ({
           metadataPath: t(msgs.defaultExportFilename) + '.' + ext
         }
       ]
-      const remoteFiles = photosToSave.map(id => ({
-        url: getMediaUrl(id, values.photos),
-        metadataPath: 'images/' + id
-      }))
+      const remoteFiles = photosToSave.map(id => {
+        // If the user is trying to export originals, use preview sized images
+        // as a fallback. TODO: Show a warning to the user that originals are
+        // missing and clearly explain why this might be and what the user can
+        // do about it.
+        const fallbackUrl =
+          values.photos === 'original' ? getMediaUrl(id, 'preview') : undefined
+        return {
+          url: getMediaUrl(id, values.photos),
+          fallbackUrl,
+          metadataPath: 'images/' + id
+        }
+      })
       const output = fsWriteStreamAtomic(filePath)
       const archive = createZip(localFiles, remoteFiles)
 

--- a/src/renderer/components/MapFilter/DataExportDialog.js
+++ b/src/renderer/components/MapFilter/DataExportDialog.js
@@ -163,7 +163,7 @@ const ExportDialogContent = ({
         }
       })
       const output = fsWriteStreamAtomic(filePath)
-      const archive = createZip(localFiles, remoteFiles)
+      const archive = createZip(localFiles, remoteFiles, { formatMessage: t })
 
       pump(archive, output, err => {
         if (err) logger.error('DataExportDialog: pump create zip', err)

--- a/src/renderer/components/MapFilter/MapExportDialog.js
+++ b/src/renderer/components/MapFilter/MapExportDialog.js
@@ -109,6 +109,11 @@ const EditDialogContent = ({
         .filter(point => point.properties.image)
         .map(point => ({
           url: getMediaUrl(point.properties.image, 'original'),
+          // If the original is missing, fallback to including the preview sized
+          // image in the export. This can happen if the phone that took the
+          // photo has only synced via another phone, and not synced directly
+          // with Mapeo Desktop
+          fallbackUrl: getMediaUrl(point.properties.image, 'preview'),
           metadataPath: 'images/' + point.properties.image
         }))
 

--- a/src/renderer/components/MapFilter/MapExportDialog.js
+++ b/src/renderer/components/MapFilter/MapExportDialog.js
@@ -117,7 +117,7 @@ const EditDialogContent = ({
           metadataPath: 'images/' + point.properties.image
         }))
 
-      const archive = createZip(localFiles, remoteFiles)
+      const archive = createZip(localFiles, remoteFiles, { formatMessage })
 
       pump(archive, output, cb)
     }


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Mapeo Crowdin project](https://crowdin.com/project/mapeo-desktop)_
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [ ] I have walked through the [QA Manual Testing
  Script](https://github.com/digidem/mapeo-desktop/blob/master/docs/QA.md) and updated it if necessary.
- [x] If my changes depend upon an update to a dependency, I have updated the package-lock.json file using `npm install --package-lock`
- [ ] My changes have been tested with the [mobile app](https://github.com/digidem/mapeo-mobile/releases). 
- [x] My changes are ready to be shipped to users on Windows, Mac, and Linux using the production version of the application built with electron-builder.

### Description

It is possible for Mapeo Desktop to be missing originals of images attached to observations. This is not obvious to the user in the app because we always show the preview-sized images (1,200px). This can happen because phone-to-phone sync only syncs thumbnails and previews, not originals, to reduce disk space usage on phones. As a result if a phone has never synced with Desktop, only the previews and thumbnails will be available.

Currently, if the user tries to export observations that link to images with missing originals, via either the Webmaps export, or the data export with "Originals" selected, then the images will be missing from the exported data, with no warning shown to the user other than a file `missing.txt` included in the exported Zip. There is no way for the user to export a webmap with the images available (the preview-sized images).

This PR changes export behaviour to fallback to including preview-sized images if no originals are available. It changes the text files included in the Zip export to `Export Errors.txt`, which lists images that are not included in the export, and `Missing Originals.txt` which lists the images for which originals are not available.

The goal of this PR is to ensure that the user has a way to export and access the images that are available, even if the originals are not. The preview size (1,200px) is adequate for most online viewing and sending electronically.

The current method of feedback to the user about what has happened, via a text file included in the export, is not ideal, and at a later date we should add clearer feedback to the user with clear actions they can take to fix this.

For WebMap exports, it may make sense to default to preview-sized images to keep the webmap bundle size down anyway.

I have tested this by doing the following exports from the app with test data:

1. Export webmap with all images present.
2. Export webmap with missing originals but preview sizes present.
3. Export webmap with missing images (originals and previews)
4. Export data zip with "originals" selected, but originals missing (previews are included in export, `Missing Originals.txt` is in export with explanation).
5. Export data zip with "previews" selected and all previews available (previews are included, as expected).
6. Export data zip with "originals" selected, but missing images (no images in export, `Export Errors.txt` shows explanation).

