### PR TITLE
Fix: Display error to user when it is a fatal mapeo core error

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,9 +99,22 @@ const main = new Main({
   isDev
 })
 
+function ipcSend (...args) {
+  try {
+    if (win && win.webContents) {
+      win.webContents.send.apply(win.webContents, args)
+      return true
+    } else return false
+  } catch (e) {
+    logger.error('exception win.webContents.send', args, e.stack)
+    return false
+  }
+}
+
 function onError (err) {
-  logger.info('SHOWING ERROR BOX')
-  electron.dialog.showErrorBox('Error', err.toString())
+  if (!ipcSend('error', err.toString())) {
+    electron.dialog.showErrorBox('Error', err.toString())
+  }
 }
 
 main.on('error', onError)
@@ -218,7 +231,7 @@ function initDirectories (done) {
     chmod(path.join(userDataPath, 'presets'), '0700', (err) => {
       if (err) logger.error('Failed to execute chmod on presets', err)
       chmod(path.join(userDataPath, 'styles'), '0700', (err) => {
-        if (err) logger.error('Failed to execute chmod on styles', err)
+        if (err && !err.message.includes('asar')) logger.error('Failed to execute chmod on styles', err)
         done()
       })
     })
@@ -227,13 +240,6 @@ function initDirectories (done) {
 
 function createServers (done) {
   // Set up Electron IPC bridge with frontend in electron-renderer process
-  function ipcSend (...args) {
-    try {
-      if (win && win.webContents) win.webContents.send.apply(win.webContents, args)
-    } catch (e) {
-      logger.error('exception win.webContents.send', args, e.stack)
-    }
-  }
   electronIpc(ipcSend)
 
   // Start Mapeo HTTP Servers

--- a/index.js
+++ b/index.js
@@ -100,8 +100,8 @@ const main = new Main({
 })
 
 function onError (err) {
-  logger.error(err)
-  electron.dialog.showErrorBox('Error', err)
+  logger.info('SHOWING ERROR BOX')
+  electron.dialog.showErrorBox('Error', err.toString())
 }
 
 main.on('error', onError)

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -30,7 +30,7 @@ function startNodeIPC (serverHandlers) {
       logger.info('configured', socketName)
       if (!logger.configured) {
         logger.configure({
-          label: 'electron-background',
+          label: 'background',
           userDataPath,
           isDev
         })

--- a/src/logger.js
+++ b/src/logger.js
@@ -2,6 +2,7 @@ const winston = require('winston')
 const path = require('path')
 const DailyRotateFile = require('winston-daily-rotate-file')
 const util = require('util')
+const { format } = require('date-fns')
 
 const store = require('./store')
 const appVersion = require('../package.json').version
@@ -70,6 +71,10 @@ class Logger {
     }
     this.configured = true
     if (this._messageQueue.length > 0) this._drainQueue()
+  }
+
+  get errorFilename () {
+    return path.join(this.dirname, format(Date.now(), 'yyyy-MM') + '.error.log')
   }
 
   debugging (debug) {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -40,6 +40,9 @@ class Main extends events.EventEmitter {
 
     this.mapeo = new Socket('mapeo')
     this.mapPrinter = new Socket('mapPrinter')
+    this.mapeo.ipc.on('error', (err) => {
+      this.emit('error', err)
+    })
     this.pid.on('close', (err) => {
       if (err) this.emit('error', err)
     })

--- a/src/renderer/components/dialogs/Error.js
+++ b/src/renderer/components/dialogs/Error.js
@@ -1,18 +1,38 @@
 import React from 'react'
+import TextareaAutosize from '@material-ui/core/TextareaAutosize'
 import Dialog from '@material-ui/core/Dialog'
 import DialogContent from '@material-ui/core/DialogContent'
+import DialogActions from '@material-ui/core/DialogActions'
 import DialogTitle from '@material-ui/core/DialogTitle'
+import Button from '@material-ui/core/Button'
 
-export default class ErrorDialog extends React.Component {
-  render () {
-    // TODO: escape this html for displaying newlines
-    return (
-      <Dialog open={this.props.open} onClose={this.props.onClose}>
-        <DialogTitle>Error</DialogTitle>
-        <DialogContent>
-          <textarea cols='20' rows='40' value={this.props.message} disabled />
-        </DialogContent>
-      </Dialog>
-    )
+import { shell } from 'electron'
+import logger from '../../../logger'
+
+import { defineMessages, useIntl } from 'react-intl'
+
+const m = defineMessages({
+  openLog: 'Open log...',
+  close: 'Close'
+})
+
+export default ({ onClose, open, message }) => {
+  const { formatMessage: t } = useIntl()
+
+  const handleDownload = event => {
+    shell.openPath(logger.errorFilename)
   }
+
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>Error</DialogTitle>
+      <DialogContent>
+        <TextareaAutosize rowsMin='5' rowsMax='30' cols='40' value={message} disabled />
+        <DialogActions>
+          <Button onClick={handleDownload}>{t(m.openLog)}</Button>
+          <Button variant='contained' color='primary' onClick={onClose}>{t(m.close)}</Button>
+        </DialogActions>
+      </DialogContent>
+    </Dialog>
+  )
 }


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Mapeo Crowdin project](https://crowdin.com/project/mapeo-desktop)_
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] I have walked through the [QA Manual Testing
  Script](https://github.com/digidem/mapeo-desktop/blob/master/docs/QA.md) and updated it if necessary.
- [x] If my changes depend upon an update to a dependency, I have updated the package-lock.json file using `npm install --package-lock`
~- [ ] My changes have been tested with the [mobile app](https://github.com/digidem/mapeo-mobile/releases).~
- [x] My changes are ready to be shipped to users on Windows, Mac, and Linux using the production version of the application built with electron-builder.

### Description

When Mapeo Core has a fatal error, it will now give the user at least some indication as to why, which can be then screenshot and sent to us. This error will also be reported to Bugsnag if they are online.

Found this while attempting to debug https://github.com/digidem/mapeo-desktop/issues/440

There will also be a log file generated at `/Mapeo/logs/YEAR-MONTH.error.log` for example, on a Mac in October `/Users/karissa/Library/Application\ Support/Mapeo/logs/2020-10.error.log`



![Screenshot from 2020-10-12 15-24-22](https://user-images.githubusercontent.com/633012/95795419-27ae4d80-0c9f-11eb-8c62-ac171dab3c08.png)


![Screenshot from 2020-10-12 15-24-31](https://user-images.githubusercontent.com/633012/95795418-2715b700-0c9f-11eb-97df-511eadb74637.png)