### PR TITLE
fix(MapExportDialog): fix React controlled/uncontrolled state warning

### DIFF
--- a/src/renderer/components/MapFilter/MapExportDialog.js
+++ b/src/renderer/components/MapFilter/MapExportDialog.js
@@ -48,16 +48,16 @@ const EditDialogContent = ({
   const classes = useStyles()
   const { formatMessage } = useIntl()
   const [saving, setSaving] = useState()
-  const [title, setTitle] = useState()
-  const [description, setDescription] = useState()
-  // const [terms, setTerms] = useState()
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  // const [terms, setTerms] = useState('')
   // const [mapStyle, setMapStyle] = useState(defaultMapStyle)
 
   const handleClose = () => {
     setSaving(false)
-    setTitle(undefined)
-    setDescription(undefined)
-    // setTerms(undefined)
+    setTitle('')
+    setDescription('')
+    // setTerms('')
     // setMapStyle(defaultMapStyle)
     onClose()
   }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/digidem/mapeo-desktop/blob/master/README.md) 

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Mapeo Crowdin project](https://crowdin.com/project/mapeo-desktop)_
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [ ] I have walked through the [QA Manual Testing
  Script](https://github.com/digidem/mapeo-desktop/blob/master/docs/QA.md) and updated it if necessary.
- [ ] If my changes depend upon an update to a dependency, I have updated the package-lock.json file using `npm install --package-lock`
- [ ] My changes have been tested with the [mobile app](https://github.com/digidem/mapeo-mobile/releases). 
- [x] My changes are ready to be shipped to users on Windows, Mac, and Linux using the production version of the application built with electron-builder.

### Description

This is a small change in the `<MapExportDialog>` that removes this warning message in the developer console:

<img width="868" alt="Screen Shot 2020-12-12 at 11 03 44 AM" src="https://user-images.githubusercontent.com/2553268/101988826-3cd93580-3c6a-11eb-8ca8-ce9832f3e974.png">

The warning is triggered when an input's value state changes between `undefined` (or `null`) and an actual value. This warning can be removed when "no value" is set to an empty string, instead.

This component is my reference for building the ICCA export dialog, which also makes similar use of controlled input state. I'm writing that component to not throw this warning and wanted to "backport" that change to this component as well. While this warning doesn't ever seem to cause user-facing bugs or performance impacts, cleaning up the console warning helps make the developer experience a little more straightforward.
