### PR TITLE
fix: do not show download dialog when closing export menu

### DIFF
--- a/src/renderer/components/MapEditor/ExportButton.js
+++ b/src/renderer/components/MapEditor/ExportButton.js
@@ -65,8 +65,12 @@ const ExportButton = () => {
     setMenuAnchor(event.currentTarget)
   }
 
-  const handleMenuItemClick = format => () => {
+  const closeMenu = () => {
     setMenuAnchor(null)
+  }
+
+  const handleMenuItemClick = format => () => {
+    closeMenu()
     const ext = format === 'shapefile' ? 'zip' : 'geojson'
     remote.dialog
       .showSaveDialog({
@@ -157,7 +161,7 @@ const ExportButton = () => {
         id='export-menu'
         anchorEl={menuAnchor}
         open={Boolean(menuAnchor)}
-        onClose={handleMenuItemClick(null)}
+        onClose={closeMenu}
       >
         <MenuItem onClick={handleMenuItemClick('geojson')}>
           <FormattedMessage {...m.exportGeoJson} />


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/digidem/mapeo-desktop/blob/master/README.md) 

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Mapeo Crowdin project](https://crowdin.com/project/mapeo-desktop)_
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [ ] I have walked through the [QA Manual Testing
  Script](https://github.com/digidem/mapeo-desktop/blob/master/docs/QA.md) and updated it if necessary.
- [ ] If my changes depend upon an update to a dependency, I have updated the package-lock.json file using `npm install --package-lock`
- [ ] My changes have been tested with the [mobile app](https://github.com/digidem/mapeo-mobile/releases). 
- [X] My changes are ready to be shipped to users on Windows, Mac, and Linux using the production version of the application built with electron-builder.

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Closing the export menu via an outside click or the <kbd>esc</kbd> key causes the download dialog to appear. This PR fixes the behavior so that those interactions only close the menu 
