### PR TITLE
chore: make flow-geojson dev dep only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15701,7 +15701,8 @@
     "flow-geojson": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/flow-geojson/-/flow-geojson-2.0.7.tgz",
-      "integrity": "sha512-6emQNxPLom64CGKSVuUWYRj5r+5gQ3fUgKzR7QyfCawRhN5uU98mpT+miQV/rddSvxY/nhlPM/GMVleJMPLG1g=="
+      "integrity": "sha512-6emQNxPLom64CGKSVuUWYRj5r+5gQ3fUgKzR7QyfCawRhN5uU98mpT+miQV/rddSvxY/nhlPM/GMVleJMPLG1g==",
+      "dev": true
     },
     "flow-parser": {
       "version": "0.111.3",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "electron-timber": "^0.5.1",
     "electron-updater": "^4.3.9",
     "flat": "^5.0.0",
-    "flow-geojson": "^2.0.7",
     "fs-cache-middleware": "^1.0.0",
     "fs-extra": "^9.0.1",
     "fs-write-stream-atomic": "^1.0.10",


### PR DESCRIPTION
`flow-geojson` is defined as both a normal dependency and a dev dependency, causing a console warning on dep installation. It only needs to be a dev dependency