### PR TITLE
fix: change publish path for win-ia32

### DIFF
--- a/builder.config.js
+++ b/builder.config.js
@@ -54,7 +54,7 @@ const config = {
     {
       provider: 's3',
       bucket: 'downloads.mapeo.app',
-      path: process.env.ARCH === 'ia32' ? '/desktop-win-ia32' : '/desktop'
+      path: process.env.ARCH === 'ia32' ? '/desktop/ia32' : '/desktop'
     },
     {
       provider: 'github',


### PR DESCRIPTION
Second thoughts about this: this way will keep the s3 folder better organized and it will be easier to write the re-write rule in https://github.com/digidem/mapeo-releases-worker
