### PR TITLE
chore: Autoupdate fixes

### DIFF
--- a/build/app-update.yml
+++ b/build/app-update.yml
@@ -1,5 +1,0 @@
-provider: generic
-url: https://downloads.mapeo.app/desktop
-channel: latest
-
-

--- a/builder.config.js
+++ b/builder.config.js
@@ -58,7 +58,8 @@ const config = {
     },
     {
       provider: 'github',
-      releaseType: 'release'
+      releaseType: 'release',
+      publishAutoUpdate: false
     }
   ],
   extraResources: [

--- a/builder.config.js
+++ b/builder.config.js
@@ -63,10 +63,6 @@ const config = {
   ],
   extraResources: [
     {
-      from: 'build/app-update.yml',
-      to: 'app-update.yml'
-    },
-    {
       from: path.dirname(require.resolve('mapeo-default-settings')),
       to: 'presets/default'
     }

--- a/src/main/auto-updater.js
+++ b/src/main/auto-updater.js
@@ -14,11 +14,21 @@ const logger = require('../logger')
 
 const PERSISTED_STORE_KEY = 'updater.channel'
 const VALID_CHANNELS = ['beta', 'latest', 'alpha']
+const RELEASE_SERVER = 'https://releases.mapeo.app'
+// We proxy our auto-updates through Cloudflare, so we treat the release server
+// as a generic http server.
+const PUBLISH_CONFIG = {
+  provider: 'generic',
+  url:
+    RELEASE_SERVER + process.env.ARCH === 'ia32' ? '/desktop/ia32' : '/desktop',
+  useMultipleRangeRequest: false
+}
 
 class MapeoUpdater extends events.EventEmitter {
   constructor () {
     super()
     // Settings
+    autoUpdater.setFeedURL(PUBLISH_CONFIG)
     autoUpdater.channel = this.channel
     autoUpdater.autoDownload = false
     autoUpdater.logger = logger
@@ -54,7 +64,7 @@ class MapeoUpdater extends events.EventEmitter {
   async _getReleaseSummary (version) {
     let releaseSummary
     try {
-      const baseUrl = `https://downloads.mapeo.app/desktop/${version}/SUMMARY`
+      const baseUrl = `https://releases.mapeo.app/desktop/${version}/SUMMARY`
       releaseSummary = await fetch(baseUrl)
     } catch (err) {
       logger.error('[UPDATER] Error getting release notes', err)


### PR DESCRIPTION
- [x] Remove unnecessary `app-update.yml` (and check it is unnecessary)
- [x] Use `https://releases.mapeo.app` for auto-updates (this is a proxy, currently proxies S3, but could use a different hosting provider in the future)
- [x] Don't publish the auto-update artifacts (`latest-mac.yml` etc.) to Github Releases, since we use S3 for auto-updates.
