### PR TITLE
fix: Hide tag & relationship editors on Territory sidebar

### DIFF
--- a/src/renderer/components/MapEditor/index.js
+++ b/src/renderer/components/MapEditor/index.js
@@ -96,6 +96,15 @@ insertCss(`
     justify-content: center;
     position: relative;
   }
+  .id-container .inspector-body .raw-tag-editor {
+    display: none;
+  }
+  .id-container .inspector-body .raw-member-editor {
+    display: none;
+  }
+  .id-container .inspector-body .raw-membership-editor {
+    display: none;
+  }  
 `)
 
 const { localStorage, location } = window


### PR DESCRIPTION

### First time contributor checklist:

- [X] I have read the [README](https://github.com/digidem/mapeo-desktop/blob/master/README.md) 

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Mapeo Crowdin project](https://crowdin.com/project/mapeo-desktop)_
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [ ] I have walked through the [QA Manual Testing Script](https://github.com/digidem/mapeo-desktop/blob/master/docs/QA.md) and updated it if necessary.
- [ ] If my changes depend upon an update to a dependency, I have updated the package-lock.json file using `npm install --package-lock`
- [ ] My changes have been tested with the [mobile app](https://github.com/digidem/mapeo-mobile/releases). 
- [X] My changes are ready to be shipped to users on Windows, Mac, and Linux using the production version of the application built with electron-builder.

### Description

Fixes #503.

This is just as much an experiment in doing open-source contributions to Mapeo code as it is fixing a very small thing discussed today with @gmaclennan - hiding several edit options in Mapeo Territory view that we are deeming to not be very helpful to show to end users.

Please let me know if I did this right in terms of filing an issue, submitting a PR, and versioning (I thought that `fix` was an appropriate prefix considering it's so small, but maybe it's a `feat` since it's not technically a bug?) I'd be happy to work with the team to improve on our guidelines for open-source contributions where helpful and needed 🙂 