### PR TITLE
Reset background color for .switch in iD Background list

### DIFF
--- a/src/renderer/components/MapEditor/index.js
+++ b/src/renderer/components/MapEditor/index.js
@@ -104,7 +104,10 @@ insertCss(`
   }
   .id-container .inspector-body .raw-membership-editor {
     display: none;
-  }  
+  }
+  .id-container .layer-list li.switch {
+    background: none;
+  }
 `)
 
 const { localStorage, location } = window


### PR DESCRIPTION
### Description

This is a small fix for https://github.com/digidem/mapeo-desktop/issues/512.
It looks like Mapeo was inheriting some stylistic properties from iD that resulted in the previously selected layer remaining highlighted with a gray background (just the same as the active layer, which is confusing).
This minor PR adds some internal CSS to override the iD style and resets the background for `.switch` class in the iD background list to none.