### PR TITLE
hide non-useful iD Background and Map Data options

### DIFF
--- a/src/renderer/components/MapEditor/index.js
+++ b/src/renderer/components/MapEditor/index.js
@@ -105,6 +105,21 @@ insertCss(`
   .id-container .inspector-body .raw-membership-editor {
     display: none;
   }  
+  .id-container .map-panes .map-data-photo-overlays {
+    display: none;
+  }
+  .id-container .map-panes .map-data-area-fills {
+    display: none;
+  }
+  .id-container .map-panes .background-overlay-list-container {
+    display: none;
+  }
+  .id-container .map-panes .background-display-options {
+    display: none;
+  }
+  .id-container .map-panes .background-offset {
+    display: none;
+  }
 `)
 
 const { localStorage, location } = window


### PR DESCRIPTION
### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Mapeo Crowdin project](https://crowdin.com/project/mapeo-desktop)_
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] I have walked through the [QA Manual Testing
  Script](https://github.com/digidem/mapeo-desktop/blob/master/docs/QA.md) and updated it if necessary.
- [ ] If my changes depend upon an update to a dependency, I have updated the package-lock.json file using `npm install --package-lock`
- [ ] My changes have been tested with the [mobile app](https://github.com/digidem/mapeo-mobile/releases). 
- [X] My changes are ready to be shipped to users on Windows, Mac, and Linux using the production version of the application built with electron-builder.

### Description
This PR hides several options in the iD Background and Map Data panes (Overlays, Display Options, Adjust Imagery Offset, Photo Overlays, and Fill Areas) that are currently not useful to Mapeo users, and in the case of Photo Overlays and Fill Areas, causing bugs to occur. Until we can figure out how these can be useful, we have decided to hide them during Mapeo QA Manual Testing (submitted by @aliya-ryan on September 14, 2021).

In the future, we may want to refactor some of these iD Editor style overrides.

Fixes #523