### PR TITLE
fix: Restore default tile server port to 5005

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var argv = minimist(process.argv.slice(2), {
   default: {
     port: 5000,
     datadir: path.join(userDataPath, 'kappa.db'),
-    tileport: 5100,
+    tileport: 5005,
     mapPrinterPort: 5200
   },
   boolean: ['headless', 'debug'],


### PR DESCRIPTION
Fixes #527

The default tile server port was changed to `5100` in 5467c19dddadd4d45391b8e9a7df7975d60d3919 :

https://github.com/digidem/mapeo-desktop/blob/5467c19dddadd4d45391b8e9a7df7975d60d3919/index.js#L27

Not entirely sure if that was intentional but for the sake of restoring previously working behavior and avoiding updates to programmatic documentation, this commit restores the default port to `5005`