### PR TITLE
fix: Reactivate Overlays menu in Background settings

### DIFF
--- a/src/renderer/components/MapEditor/index.js
+++ b/src/renderer/components/MapEditor/index.js
@@ -114,9 +114,6 @@ insertCss(`
   .id-container .map-panes .map-data-area-fills {
     display: none;
   }
-  .id-container .map-panes .background-overlay-list-container {
-    display: none;
-  }
   .id-container .map-panes .background-display-options {
     display: none;
   }


### PR DESCRIPTION
Resolves https://github.com/digidem/mapeo-desktop/issues/532

### Description

This PR unhides the Overlays submenu in the Background menu, since this menu now provides useful functionality for an end user in the latest version of Mapeo Desktop.
