### PR TITLE
fix: Fix translation entry for default report file name

### DIFF
--- a/messages/renderer/en.json
+++ b/messages/renderer/en.json
@@ -374,7 +374,7 @@
   },
   "renderer.components.MapFilter.ReportView.ReportViewContent.defaultReportName": {
     "description": "Default filename for a report (prefixed with date as YYYY-MM-YY)",
-    "message": "Mapeo Monitoring Report.pdf"
+    "message": "Mapeo Observation Report.pdf"
   },
   "renderer.components.MapFilter.ReportView.ReportViewContent.nextPage": {
     "description": "Button for navigating to the next page in the report",


### PR DESCRIPTION
Forgot to run `extract-messages` command when we updated a translatable message [here](https://github.com/digidem/mapeo-desktop/commit/72f9387). In the future, this will be better automated using git hooks (see #534)