### PR TITLE
chore: Re-enable windows signing

### DIFF
--- a/builder.config.js
+++ b/builder.config.js
@@ -26,10 +26,7 @@ const config = {
     target: 'NSIS',
     artifactName: 'Installar_Mapeo_v${version}_${os}-${env.ARCH}.${ext}',
     rfc3161TimeStampServer: 'http://timestamp.digicert.com',
-    timeStampServer: 'http://timestamp.digicert.com',
-    forceCodeSigning: false,
-    signAndEditExecutable: false,
-    sign: async () => {}
+    timeStampServer: 'http://timestamp.digicert.com'
   },
   linux: {
     target: ['AppImage', 'deb'],


### PR DESCRIPTION
We updated our certificate so should be able to enable signing for windows again