### PR TITLE
fix: Log instead of emit errors from IPC

### DIFF
--- a/src/client-ipc.js
+++ b/src/client-ipc.js
@@ -83,6 +83,11 @@ class IPC extends EventEmitter {
         logger.debug('Received broadcast message', msg)
 
         const { name, args } = msg
+        if (name === 'error') {
+          // TODO: Think through how/whether to handle these errors in the UX
+          logger.error(args[0])
+          return
+        }
         this.emit(name, args)
       }
     }

--- a/src/client-ipc.js
+++ b/src/client-ipc.js
@@ -85,7 +85,7 @@ class IPC extends EventEmitter {
         const { name, args } = msg
         if (name === 'error') {
           // TODO: Think through how/whether to handle these errors in the UX
-          logger.error(args[0])
+          logger.error('Broadcast message error', args)
           return
         }
         this.emit(name, args)


### PR DESCRIPTION
Closes #613 

I didn't realize that the Node EventEmitter will throw if you do `emit("error")` but do not handle the error. We currently don't handle errors on the broadcast channel, so for now just logging them. The whole error handling in Mapeo Core / IPC needs a rethink.