### PR TITLE
fix: Hide generic geometry presets in territory

### DIFF
--- a/src/renderer/components/MapEditor/index.js
+++ b/src/renderer/components/MapEditor/index.js
@@ -96,6 +96,11 @@ insertCss(`
     justify-content: center;
     position: relative;
   }
+  .id-container .inspector-body .preset-point,
+  .id-container .inspector-body .preset-line,
+  .id-container .inspector-body .preset-area {
+    display: none;
+  }
   .id-container .inspector-body .raw-tag-editor {
     display: none;
   }


### PR DESCRIPTION

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Mapeo Crowdin project](https://crowdin.com/project/mapeo-desktop)_
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] I have walked through the [QA Manual Testing Script](https://github.com/digidem/mapeo-desktop/blob/master/docs/QA.md) and updated it if necessary.
- [ ] If my changes depend upon an update to a dependency, I have updated the package-lock.json file using `npm install --package-lock`
- [ ] My changes have been tested with the [mobile app](https://github.com/digidem/mapeo-mobile/releases). 
- [ ] My changes are ready to be shipped to users on Windows, Mac, and Linux using the production version of the application built with electron-builder.

### Description

Resolves https://github.com/digidem/mapeo-desktop/issues/620

Forgot to add conventional commits format initially, so rewrote the commit messaging - hence the multiple commits. Will squash when merging upon approval.