### PR TITLE
fix: hide unhelpful iD Help pane until properly customized for Mapeo

### DIFF
--- a/src/renderer/components/MapEditor/index.js
+++ b/src/renderer/components/MapEditor/index.js
@@ -112,7 +112,10 @@ insertCss(`
   }
   .id-container .layer-list li.switch {
     background: none;
-  }  
+  }
+  .id-container .map-controls .help-control {
+    display: none;
+  }
   .id-container .map-panes .map-data-photo-overlays {
     display: none;
   }


### PR DESCRIPTION
### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Mapeo Crowdin project](https://crowdin.com/project/mapeo-desktop)_
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] I have walked through the [QA Manual Testing
  Script](https://github.com/digidem/mapeo-desktop/blob/master/docs/QA.md) and updated it if necessary.
- [ ] If my changes depend upon an update to a dependency, I have updated the package-lock.json file using `npm install --package-lock`
- [ ] My changes have been tested with the [mobile app](https://github.com/digidem/mapeo-mobile/releases). 
- [ ] My changes are ready to be shipped to users on Windows, Mac, and Linux using the production version of the application built with electron-builder.

### Description

Partial fix for #452 although there are other things to address. 

This PR hides the `Help` button in Mapeo Desktop Territory, since the content of the Help pane that it opens is leftover from iD Editor / OSM and has not at all been customized for Mapeo. It is more confusing than helpful. It also provides a link back to the Walkthrough which is buggy and also not customized for Mapeo.

Trainers from the field report back that they have to tell their users to ignore this pane, which does not inspire confidence. So until we have customized the content, let's hide it for now.

There are still two remaining tasks to fully address disabling this inherited feature, however:

1) The `H` key still opens this pane. This needs to be deactivated.
2) Upon first load of Mapeo, the user is prompted to do a Walkthrough from iD / OSM. I recommend disabling this as well until the buggy aspects of it (i.e. offset transparency overlays) it's been customized for Mpaoe.

![image](https://user-images.githubusercontent.com/31662219/144630944-895e07a3-31e6-4153-856b-33eaf57b50a3.png)
