### PR TITLE
fix: hiding more superfluous iD Editor content

### DIFF
--- a/src/renderer/components/MapEditor/index.js
+++ b/src/renderer/components/MapEditor/index.js
@@ -101,6 +101,10 @@ insertCss(`
   .id-container .inspector-body .preset-area {
     display: none;
   }
+  }
+  .id-container .inspector-body .more-fields {
+    display: none;
+  }
   .id-container .inspector-body .raw-tag-editor {
     display: none;
   }
@@ -110,9 +114,19 @@ insertCss(`
   .id-container .inspector-body .raw-membership-editor {
     display: none;
   }
+  
+  .id-container .save-success .link-out { 
+    display: none;
+  }
+  .id-container .save-success .summary-table { 
+    display: none;
+  }
   .id-container .layer-list li.switch {
     background: none;
   }  
+  .id-container .map-panes .imagery-faq {
+    display: none;
+  }
   .id-container .map-panes .map-data-photo-overlays {
     display: none;
   }


### PR DESCRIPTION
### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Mapeo Crowdin project](https://crowdin.com/project/mapeo-desktop)_
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] I have walked through the [QA Manual Testing
  Script](https://github.com/digidem/mapeo-desktop/blob/master/docs/QA.md) and updated it if necessary.
- [ ] If my changes depend upon an update to a dependency, I have updated the package-lock.json file using `npm install --package-lock`
- [ ] My changes have been tested with the [mobile app](https://github.com/digidem/mapeo-mobile/releases). 
- [ ] My changes are ready to be shipped to users on Windows, Mac, and Linux using the production version of the application built with electron-builder.

### Description

This PR hides a few more things in iD Editor (Territory) that are not relevant to, or currently useful in, Mapeo:

* A few broken OSM changeset links seen upon saving edits:
![image](https://user-images.githubusercontent.com/31662219/144637136-06f613a2-5c86-4fe2-9b8c-d638652c1ad5.png)

* The `Add field` field in Edit feature which does not currently populate from the configuration, and is therefore confusing to our users.
![image](https://user-images.githubusercontent.com/31662219/144637304-12fb813c-81a9-4386-9c08-f3e7c8799692.png)

* The `Imagery info / Report a Problem`  link at the bottom of `Background` which pertains to the online Esri / Bing / Mapbox layers brings one to the iD Github; not something our users are likely to know what to do with.
![image](https://user-images.githubusercontent.com/31662219/144637730-733cf2a0-5916-459e-8ab1-f78a92b6d63b.png)
