### PR TITLE
chore: Made closing text translatable

### DIFF
--- a/messages/main/en.json
+++ b/messages/main/en.json
@@ -101,5 +101,6 @@
   "convert-button": "Copy to Editor",
   "convert-number": "You have filtered your data to show {count} observations",
   "convert-detail": "{count} of these are not yet in Map Editor. Click OK to move these {count} observations to Map Editor.",
-  "convert-nothing": "These are all already in the Map Editor."
+  "convert-nothing": "These are all already in the Map Editor.",
+  "closing-screen": "Mapeo is closing..."
 }

--- a/src/main/changeClosing.js
+++ b/src/main/changeClosing.js
@@ -1,0 +1,3 @@
+const EventEmitter = require('events')
+
+exports.changeClosingEvent = new EventEmitter()

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -4,6 +4,8 @@ const updater = require('./auto-updater')
 const logger = require('../logger')
 const userConfig = require('./user-config')
 const i18n = require('./i18n')
+const path = require('path')
+const fs = require('fs')
 
 /**
  * Miscellaneous ipcMain calls that don't hit mapeo-core
@@ -81,8 +83,12 @@ module.exports = function (ipcSend) {
     onError(new Error(message))
   })
 
-  ipcMain.on('set-locale', function (ev, locale) {
-    app.translations = i18n.setLocale(locale)
+  ipcMain.on('set-locale', function (ev, { lang, message }) {
+    const closeFilePath = path.join(app.getPath('temp'), 'closing' + '.json')
+    //I am purposely doing this syncronously as it is a very small file and we want
+    //to make sure it get written before the user is able to close
+    fs.writeFileSync(closeFilePath, JSON.stringify({ closingMessage: message }))
+    app.translations = i18n.setLocale(lang)
     i18n.save()
   })
 

--- a/src/main/windows.js
+++ b/src/main/windows.js
@@ -86,6 +86,9 @@ function ClosingWindow () {
     center: true,
     frame: false,
     show: false,
-    alwaysOnTop: true
+    alwaysOnTop: true,
+    webPreferences: {
+      preload: path.join(__dirname, '../../static/closingPreload.js')
+    }
   })
 }

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -72,9 +72,7 @@ const App = () => {
   }, [backendState])
 
   const handleLanguageChange = React.useCallback(lang => {
-    const message = msgs[lang]['closing']
-    ipcRenderer.send('set-locale', { lang, message })
-    console.log(message)
+    ipcRenderer.send('set-locale', lang)
     setLocale(lang)
     // Ideally this would just re-render the app in the new locale, but the way
     // we squeeze iD editor into React and patch in React Components on top of

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -9,6 +9,7 @@ import CssBaseline from '@material-ui/core/CssBaseline'
 import logger from '../logger'
 import theme from './theme'
 import Home from './components/Home'
+import messages from './components/MapFilter/messages'
 
 if (!logger.configured) {
   logger.configure({
@@ -71,7 +72,9 @@ const App = () => {
   }, [backendState])
 
   const handleLanguageChange = React.useCallback(lang => {
-    ipcRenderer.send('set-locale', lang)
+    const message = msgs[lang]['closing']
+    ipcRenderer.send('set-locale', { lang, message })
+    console.log(message)
     setLocale(lang)
     // Ideally this would just re-render the app in the new locale, but the way
     // we squeeze iD editor into React and patch in React Components on top of

--- a/static/closing.html
+++ b/static/closing.html
@@ -42,7 +42,7 @@
   </head>
   <body>
     <div class="root">
-      <h1>
+      <h1 id="closingText">
         Esperando que termina Mapeo... 
       </h1>
     </div>

--- a/static/closingPreload.js
+++ b/static/closingPreload.js
@@ -1,9 +1,9 @@
-const {app, remote } = require('electron')
+const { remote } = require('electron')
 
 const closing = require(remote.app.getPath("temp")+"closing.json")
 
-window.addEventListener('DOMContentLoaded', () => {{
+window.addEventListener('DOMContentLoaded', () => {
     const closingH1 = document.getElementById("closingText")
     if (closingH1) closingH1.innerHTML=closing.closingMessage;
     console.log(closingH1)
-}})
+})

--- a/static/closingPreload.js
+++ b/static/closingPreload.js
@@ -1,0 +1,9 @@
+const {app, remote } = require('electron')
+
+const closing = require(remote.app.getPath("temp")+"closing.json")
+
+window.addEventListener('DOMContentLoaded', () => {{
+    const closingH1 = document.getElementById("closingText")
+    if (closingH1) closingH1.innerHTML=closing.closingMessage;
+    console.log(closingH1)
+}})


### PR DESCRIPTION
# Closing Text Translatable
In Message/Main/, closing string added. This string is added, via the DOM, to the closing.html.

When language is changed , ipcRenderer('set-locale') is fired, this sets off a fs.writeFile(), in the main process, which writes the closing string to a JSON file. Then the JSON file is read in a preload script for closing.html, and is appended to the DOM.

![Kapture 2021-12-10 at 13 07 11](https://user-images.githubusercontent.com/67773827/145614470-318e0f44-4fa0-44e0-9c12-ecf8e4869658.gif)

