### PR TITLE
feat: Support custom colors for displayed observations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39429,6 +39429,11 @@
       "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
       "dev": true
     },
+    "validate-color": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/validate-color/-/validate-color-2.2.1.tgz",
+      "integrity": "sha512-1eDb1zqP6W6bbfKKl6dRXObelNoQpW7aF3BUTh2AivWuhcD0pa3ejwURWqrVsyKJMLBMlHLFcM3sj5J+dSFhbg=="
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
     "tiny-typed-emitter": "^2.0.3",
     "uri-templates": "^0.2.0",
     "utm": "^1.1.1",
+    "validate-color": "^2.2.1",
     "winston": "^3.2.1",
     "winston-daily-rotate-file": "^4.4.2",
     "yazl": "^2.5.1"

--- a/src/renderer/components/MapFilter/MapView/MapView.js
+++ b/src/renderer/components/MapFilter/MapView/MapView.js
@@ -40,6 +40,7 @@ const MapView = (
           observations={filteredObservations}
           getPreset={getPreset}
           getMedia={getMedia}
+          presets={presets}
           {...otherProps}
         />
       )}

--- a/src/renderer/components/MapFilter/MapView/MapViewContent.js
+++ b/src/renderer/components/MapFilter/MapView/MapViewContent.js
@@ -78,7 +78,8 @@ const MapViewContent = (
     initialMapPosition = {},
     onMapMove = noop,
     mapStyle = 'mapbox://styles/mapbox/outdoors-v10',
-    print = false
+    print = false,
+    presets
   }: Props,
   ref
 ) => {
@@ -239,6 +240,7 @@ const MapViewContent = (
       <ObservationLayer
         observations={observations}
         onClick={onClick}
+        presets={presets}
         onMouseLeave={handleMouseLeave}
         onMouseMove={handleMouseMove}
         print={print}


### PR DESCRIPTION
Closes #615 

Notes:
- Supports the use of a `color` field for a preset, which should be any color that's supported by the [CSS3 color spec](https://www.w3.org/TR/css-color-3/)
- Fallback color is the same red color we've been using prior to this change
- We should technically update `mapeo-schema` to reflect this, but considering upcoming work it may not be worth doing for now 
- Adds a new dependency: [validate-color](https://github.com/dreamyguy/validate-color)

---

Preview:
- I added a color field for the following default categories as follows: 
```js
// cave.json
{ 
  "color": "invalid-color",
  ...
}

// threat.json
{ 
  "color": "firebrick",
  ...
}

// river.json
{ 
  "color": "#0000cd",
  ...
}

// streamjson
{ 
  "color": "#0cd",
  ...
}
```

![615-color-dots-desktop](https://user-images.githubusercontent.com/18542095/146835054-9381824d-71a3-4023-961b-613d9708900a.gif)


