### PR TITLE
fix: Properly use fallback settings metadata when user-defined one is missing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2444,9 +2444,9 @@
       }
     },
     "@mapeo/settings": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@mapeo/settings/-/settings-2.1.2.tgz",
-      "integrity": "sha512-2O7qeEqLia9uXB3cH09l1xsk55/Ww3dDzWXr21EpGQBBBChUhLzpiU2Li0lSzqJywwUmgz8bIZy+RvcMKQEG7w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@mapeo/settings/-/settings-2.1.3.tgz",
+      "integrity": "sha512-ePg5DPgcRXAweNgh/Xl1z0KAIuIowo0lEYH+fgWmVmdOMHWMZWvr5pPnSHi5JVA3/fmJHPqlwvKxvFu+UdNQoA==",
       "requires": {
         "mkdirp": "^1.0.4",
         "pump": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.11.1",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "@mapbox/sexagesimal": "^1.2.0",
-    "@mapeo/settings": "^2.1.2",
+    "@mapeo/settings": "^2.1.3",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.5.1",
     "@material-ui/lab": "^4.0.0-alpha.53",


### PR DESCRIPTION
Upgrades `mapeo-settings` to v2.1.3 which includes a fix to prevent a default value for settings metadata from being set at the dep level. See https://github.com/digidem/mapeo-settings/pull/7 for more context