### PR TITLE
fix(obs): only show filters for fields in point presets

### DIFF
--- a/src/renderer/components/MapFilter/MapFilter.js
+++ b/src/renderer/components/MapFilter/MapFilter.js
@@ -135,9 +135,19 @@ function usePresets () {
       try {
         const data = await api.getPresets()
         const presets = mapToArray(data.presets)
-        const fields = mapToArray(data.fields)
-        const presetsWithFields = presets
+          // Only point data is shown in the Observation view, so only show
+          // presets which match point data
           .filter(p => p.geometry.includes('point'))
+        const usedFields = new Set()
+        for (const preset of presets) {
+          for (const fieldId of preset.fields) {
+            usedFields.add(fieldId)
+          }
+        }
+        const fields = mapToArray(data.fields)
+          // Only show fields which are used in a preset
+          .filter(field => usedFields.has(field.id))
+        const presetsWithFields = presets
           // Replace field ids with full field definitions
           .map(p => addFieldDefinitions(p, fields))
         setLoading(false)


### PR DESCRIPTION
**As yet untested**. Pending testing from build.

A quick fix for an issue where the filter pane in observation view shows filters for fields that do not relate to data that would appear in observation view. E.g. filters will currently show for fields which are only used by presets for areas, but the observation view only displays point data. Also, currently filters will show for fields that are defined in a config file, but not used by any presets.

Caveat: In the future it might be better to filter which fields appear based on the dataset rather than the presets.