### PR TITLE
Add Mapeo Web support

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@fortawesome/react-fontawesome": "^0.1.4",
     "@mapbox/sexagesimal": "^1.2.0",
     "@mapeo/settings": "^2.1.2",
+    "@mapeo/core": "github:digidem/mapeo-core#ws-sync",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.5.1",
     "@material-ui/lab": "^4.0.0-alpha.53",

--- a/src/background/mapeo-core/index.js
+++ b/src/background/mapeo-core/index.js
@@ -158,10 +158,13 @@ module.exports = function init (opts) {
     mapeo.syncStart(target, createFile)
   }
 
-  handlers['sync-join'] = async () => {
-    const mapeo = await manager.deferredMapeo
-    mapeo.syncJoin()
-  }
+handlers['sync-connect'] = async (url) => {
+  manager.mapeo.syncConnect(url)
+}
+
+handlers['sync-join'] = async () => {
+  manager.mapeo.syncJoin()
+}
 
   handlers['sync-leave'] = async () => {
     const mapeo = await manager.deferredMapeo

--- a/src/background/mapeo-core/index.js
+++ b/src/background/mapeo-core/index.js
@@ -158,8 +158,8 @@ module.exports = function init (opts) {
     mapeo.syncStart(target, createFile)
   }
 
-handlers['sync-connect'] = async (url) => {
-  manager.mapeo.syncConnect(url)
+handlers['sync-connect-cloud'] = async (url) => {
+  manager.mapeo.connectCloud(url)
 }
 
 handlers['sync-join'] = async () => {

--- a/src/background/mapeo-core/mapeo.js
+++ b/src/background/mapeo-core/mapeo.js
@@ -135,7 +135,19 @@ class MapeoRPC {
     })
   }
 
-  syncStart (target = {}, createFile) {
+  syncConnect(url) {
+    try {
+      logger.debug(
+        'Connecting to MapeoWeb',
+        this.encryptionKey && this.encryptionKey.slice(0, 4)
+      )
+      this.core.sync.connectWebsocket(url, this.encryptionKey)
+    } catch (e) {
+      this._handleError('syncConnect', e)
+    }
+  }
+
+  syncStart (target = {}) {
     logger.info('Sync start request:', target)
 
     const sync = this.core.sync.replicate(target, {

--- a/src/background/mapeo-core/mapeo.js
+++ b/src/background/mapeo-core/mapeo.js
@@ -135,7 +135,7 @@ class MapeoRPC {
     })
   }
 
-  syncConnect(url) {
+  connectCloud(url) {
     try {
       logger.debug(
         'Connecting to MapeoWeb',
@@ -144,7 +144,7 @@ class MapeoRPC {
       )
       this.core.sync.connectWebsocket(url, this.encryptionKey)
     } catch (e) {
-      this._handleError('syncConnect', e)
+      this._handleError('connectCloud', e)
     }
   }
 

--- a/src/background/mapeo-core/mapeo.js
+++ b/src/background/mapeo-core/mapeo.js
@@ -139,6 +139,7 @@ class MapeoRPC {
     try {
       logger.debug(
         'Connecting to MapeoWeb',
+        url,
         this.encryptionKey && this.encryptionKey.slice(0, 4)
       )
       this.core.sync.connectWebsocket(url, this.encryptionKey)

--- a/src/renderer/components/SyncView/Searching.js
+++ b/src/renderer/components/SyncView/Searching.js
@@ -13,11 +13,12 @@ const m = defineMessages({
     'Make sure devices are turned on and connected to the same wifi network'
 })
 
-const Searching = () => {
+const Searching = ({children}) => {
   const cx = useStyles()
   const { formatMessage: t } = useIntl()
   return (
     <div className={cx.searchingWrapper}>
+      {children}
       <div className={cx.searching}>
         <Loader />
         <div className={cx.searchingText}>

--- a/src/renderer/components/SyncView/SyncAppBar.js
+++ b/src/renderer/components/SyncView/SyncAppBar.js
@@ -60,7 +60,7 @@ const m = defineMessages({
   newSyncfile: 'Create new syncfile…',
   connectMapeoWeb: 'Connect to Mapeo Web'
 })
-const SyncAppBar = ({ onClickSelectSyncfile, onClickNewSyncfile, onClickConnectMapeoWeb }) => {
+const SyncAppBar = ({ onClickSelectSyncfile, onClickNewSyncfile, onClickConnectMapeoWeb, canConnectMapeoWeb }) => {
   const cx = useStyles()
   const { formatMessage: t } = useIntl()
   const [currentConnection, setCurrentConnection] = useState(null)
@@ -194,14 +194,16 @@ const SyncAppBar = ({ onClickSelectSyncfile, onClickNewSyncfile }) => {
         >
           {t(m.newSyncfile)}
         </Button>
-        <Button
-          onClick={onClickConnectMapeoWeb}
-          color="inherit"
-          variant="outlined"
-          className={cx.button}
-        >
-          {t(m.connectMapeoWeb)}
-        </Button>
+        { canConnectMapeoWeb ? (
+          <Button
+            onClick={onClickConnectMapeoWeb}
+            color="inherit"
+            variant="outlined"
+            className={cx.button}
+          >
+            {t(m.connectMapeoWeb)}
+          </Button>
+        ) : null }
       </Toolbar>
     </AppBar>
   )

--- a/src/renderer/components/SyncView/SyncAppBar.js
+++ b/src/renderer/components/SyncView/SyncAppBar.js
@@ -57,10 +57,10 @@ const m = defineMessages({
   // Button to sync from an existing sync file
   selectSyncfile: 'Sync from a file…',
   // Button to create a new sync file
-  newSyncfile: 'Create new syncfile…'
+  newSyncfile: 'Create new syncfile…',
+  connectMapeoWeb: 'Connect to Mapeo Web'
 })
-
-const WifiStatus = () => {
+const SyncAppBar = ({ onClickSelectSyncfile, onClickNewSyncfile, onClickConnectMapeoWeb }) => {
   const cx = useStyles()
   const { formatMessage: t } = useIntl()
   const [currentConnection, setCurrentConnection] = useState(null)
@@ -193,6 +193,14 @@ const SyncAppBar = ({ onClickSelectSyncfile, onClickNewSyncfile }) => {
           className={cx.button}
         >
           {t(m.newSyncfile)}
+        </Button>
+        <Button
+          onClick={onClickConnectMapeoWeb}
+          color="inherit"
+          variant="outlined"
+          className={cx.button}
+        >
+          {t(m.connectMapeoWeb)}
         </Button>
       </Toolbar>
     </AppBar>

--- a/src/renderer/components/SyncView/SyncAppBar.js
+++ b/src/renderer/components/SyncView/SyncAppBar.js
@@ -57,10 +57,9 @@ const m = defineMessages({
   // Button to sync from an existing sync file
   selectSyncfile: 'Sync from a file…',
   // Button to create a new sync file
-  newSyncfile: 'Create new syncfile…',
-  connectMapeoWeb: 'Connect to Mapeo Web'
+  newSyncfile: 'Create new syncfile…'
 })
-const SyncAppBar = ({ onClickSelectSyncfile, onClickNewSyncfile, onClickConnectMapeoWeb, canConnectMapeoWeb }) => {
+const SyncAppBar = ({ onClickSelectSyncfile, onClickNewSyncfile }) => {
   const cx = useStyles()
   const { formatMessage: t } = useIntl()
   const [currentConnection, setCurrentConnection] = useState(null)
@@ -194,16 +193,6 @@ const SyncAppBar = ({ onClickSelectSyncfile, onClickNewSyncfile }) => {
         >
           {t(m.newSyncfile)}
         </Button>
-        { canConnectMapeoWeb ? (
-          <Button
-            onClick={onClickConnectMapeoWeb}
-            color="inherit"
-            variant="outlined"
-            className={cx.button}
-          >
-            {t(m.connectMapeoWeb)}
-          </Button>
-        ) : null }
       </Toolbar>
     </AppBar>
   )

--- a/src/renderer/components/SyncView/SyncFooter.js
+++ b/src/renderer/components/SyncView/SyncFooter.js
@@ -1,27 +1,15 @@
-import React, {useEffect, useState} from 'react'
+import React from 'react'
 import AppBar from '@material-ui/core/AppBar'
 import Toolbar from '@material-ui/core/Toolbar'
 import Typography from '@material-ui/core/Typography'
 import {makeStyles} from '@material-ui/core/styles'
-import api from '../../new-api'
+import {useConfig} from '../../hooks/useConfig'
 
 const visibleKeyLength = 5
 
 const SyncFooter = () => {
   const cx = useStyles()
-  const [encryptionKey, setEncryptionKey] = useState(null)
-  const [metadata, setMetadata] = useState(null)
-
-  // Check encryption key on load
-  useEffect(() => {
-    const check = async () => {
-      const encryptionKey = await api.getEncryptionKey()
-      setEncryptionKey(encryptionKey)
-      const metadata = await api.getMetadata()
-      setMetadata(metadata)
-    }
-    check()
-  }, [])
+  const {metadata, encryptionKey} = useConfig()
 
   return (
     <AppBar position='static' color='default' elevation={0} className={cx.root}>

--- a/src/renderer/components/SyncView/SyncTarget.js
+++ b/src/renderer/components/SyncView/SyncTarget.js
@@ -4,6 +4,7 @@ import PhoneIcon from '@material-ui/icons/PhoneAndroid'
 import LaptopIcon from '@material-ui/icons/Laptop'
 import FileIcon from '@material-ui/icons/Usb'
 import ErrorIcon from '@material-ui/icons/Error'
+import CloudIcon from '@material-ui/icons/CloudUpload'
 import Paper from '@material-ui/core/Paper'
 import Typography from '@material-ui/core/Typography'
 import SyncButton from './SyncButton'
@@ -57,6 +58,8 @@ const SyncTarget = ({
             <LaptopIcon fontSize='inherit' className={cx.icon} />
           ) : deviceType === 'file' ? (
             <FileIcon fontSize='inherit' className={cx.icon} />
+          ) : deviceType === 'cloud' ? (
+            <CloudIcon fontSize='inherit' className={cx.icon} />
           ) : (
             <PhoneIcon fontSize='inherit' className={cx.icon} />
           )}

--- a/src/renderer/components/SyncView/index.js
+++ b/src/renderer/components/SyncView/index.js
@@ -74,25 +74,57 @@ const SyncView = ({ focusState }) => {
     connectMapeoWeb()
   }
 
+	const hasCloudPeer = peers.find(({deviceType}) => deviceType === 'cloud')
+  const mapeoWebSyncButton = hasCloudPeer ? (
+    (hasCloudPeer.status !== 'complete') ? (
+      <SyncTarget
+        key={hasCloudPeer.id}
+        {...hasCloudPeer}
+        onClick={() => syncPeer(hasCloudPeer.id)}
+      />
+    ) : (
+      <SyncTarget
+        key={hasCloudPeer.id}
+        {...hasCloudPeer}
+        connected={true}
+        onClick={handleClickConnectMapeoWeb}
+      />
+    )
+  ) : canConnectMapeoWeb ? (
+    <SyncTarget
+      name="Mapeo Cloud Sync"
+      deviceType="cloud"
+      status={'ready'}
+      connected
+      onClick={handleClickConnectMapeoWeb}
+    />
+  ) : null
+
   return (
     <div className={cx.root}>
       <SyncAppBar
-        canConnectMapeoWeb={canConnectMapeoWeb}
         onClickSelectSyncfile={handleClickSelectSyncfile}
         onClickNewSyncfile={handleClickNewSyncfile}
-        onClickConnectMapeoWeb={handleClickConnectMapeoWeb}
       />
       {peers.length === 0 && focusState === 'focused' ? (
-        <Searching />
+        mapeoWebSyncButton ? (
+          <SyncGrid>
+            {mapeoWebSyncButton}
+            <Searching/>
+          </SyncGrid>
+        ) : (
+          <Searching/>
+        )
       ) : (
         <SyncGrid>
-          {peers.map(peer => (
+          {mapeoWebSyncButton}
+          {peers.map(peer => ((peer.deviceType !== 'cloud') && (
             <SyncTarget
               key={peer.id}
               {...peer}
               onClick={() => syncPeer(peer.id)}
             />
-          ))}
+          )))}
         </SyncGrid>
       )}
       <SyncFooter />

--- a/src/renderer/components/SyncView/index.js
+++ b/src/renderer/components/SyncView/index.js
@@ -40,7 +40,7 @@ const fileDialogFilters = [
 const SyncView = ({ focusState }) => {
   const cx = useStyles()
   const listenForSyncPeers = focusState === 'focused'
-  const [peers, syncPeer] = usePeers(listenForSyncPeers)
+  const [peers, syncPeer, connectMapeoWeb] = usePeers(listenForSyncPeers)
   const { formatMessage: t } = useIntl()
   logger.debug('render peers', peers)
 
@@ -70,11 +70,18 @@ const SyncView = ({ focusState }) => {
     }).catch(err => logger.error(err))
   }
 
+  const handleClickConnectMapeoWeb = () => {
+		console.log('Connect to mapeo web!')
+		connectMapeoWeb('wss://cloud.mapeo.app')
+		// connectMapeoWeb('ws://localhost:42069')
+  }
+
   return (
     <div className={cx.root}>
       <SyncAppBar
         onClickSelectSyncfile={handleClickSelectSyncfile}
         onClickNewSyncfile={handleClickNewSyncfile}
+        onClickConnectMapeoWeb={handleClickConnectMapeoWeb}
       />
       {peers.length === 0 && focusState === 'focused' ? (
         <Searching />
@@ -201,7 +208,12 @@ function usePeers (listen) {
     [serverPeers]
   )
 
-  return [peers, syncPeer]
+  const connectMapeoWeb = useCallback((url) => {
+		logger.info('Request connect mapeo web start', url)
+		api.syncConnect(url)
+  }, [serverPeers])
+
+  return [peers, syncPeer, connectMapeoWeb]
 }
 
 /**

--- a/src/renderer/hooks/useConfig.js
+++ b/src/renderer/hooks/useConfig.js
@@ -1,0 +1,20 @@
+import {useEffect, useState} from 'react'
+import api from '../new-api'
+
+export function useConfig () {
+const [encryptionKey, setEncryptionKey] = useState(null)
+  const [metadata, setMetadata] = useState({})
+
+  // Check encryption key on load
+  useEffect(() => {
+    const check = async () => {
+      const encryptionKey = await api.getEncryptionKey()
+      setEncryptionKey(encryptionKey)
+      const metadata = await api.getMetadata()
+      setMetadata(metadata)
+    }
+    check()
+  }, [])
+
+  return {encryptionKey, metadata}
+}

--- a/src/renderer/new-api.js
+++ b/src/renderer/new-api.js
@@ -180,6 +180,11 @@ function Api ({ baseUrl, mapUrl, ipc }) {
       ipc.send('sync-start', { target, createFile })
     },
 
+    // Connect to a MapeoWeb server
+    syncConnect: function syncConnect (url) {
+      ipc.send('sync-connect', url)
+    },
+
     exportData: function (filename, { format = 'geojson' } = {}) {
       return new Promise((resolve, reject) => {
         ipc.send('export-data', { filename, format }, err => {

--- a/src/renderer/new-api.js
+++ b/src/renderer/new-api.js
@@ -181,8 +181,8 @@ function Api ({ baseUrl, mapUrl, ipc }) {
     },
 
     // Connect to a MapeoWeb server
-    syncConnect: function syncConnect (url) {
-      ipc.send('sync-connect', url)
+    connectCloud: function syncConnect (url) {
+      ipc.send('sync-connect-cloud', url)
     },
 
     exportData: function (filename, { format = 'geojson' } = {}) {


### PR DESCRIPTION
Adds support for synchronization over secure websockets with an online Mapeo server. Can be used as a cloud backup, or as a way of synchronizing between two devices that are not online at the same time over the internet.

Currently this feature is unstable. It works and data does sync between devices, but the UI will often hang without showing completion of the sync, although data does seem to eventually appear in the app.

To activate web sync, first the project key needs to be authorized on the deployment of [Mapeo Web](https://github.com/digidem/mapeo-web/), then the URL to the Mapeo Web deployment needs to be included in the project config (see the `syncServer` [configuration option](https://github.com/digidem/mapeo-settings-builder/) in the settings `metadata.json` file).

