### PR TITLE
chore: fix CI builds when run from a forked repo

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -53,7 +53,8 @@ jobs:
         env:
           CI: true
       - name: Publish
-        if: github.repository == 'digidem/mapeo-desktop'
+        # Currently undocumented, but if it is None (e.g. PR from a fork) then secrets are not defined
+        if: github.secret_source != 'None'
         run: |
           npm run dist -- --${{matrix.config.arch}}
         env:
@@ -71,7 +72,8 @@ jobs:
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           MAPEO_VARIANT: ${{ matrix.variant }}
       - name: Publish (unsigned)
-        if: github.repository != 'digidem/mapeo-desktop'
+        # Currently undocumented, but if it is None (e.g. PR from a fork) then secrets are not defined
+        if: github.secret_source == 'None'
         run: |
           npm run dist -- --${{matrix.config.arch}}
         env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -53,6 +53,7 @@ jobs:
         env:
           CI: true
       - name: Publish
+        if: github.repository == 'digidem/mapeo-desktop'
         run: |
           npm run dist -- --${{matrix.config.arch}}
         env:
@@ -68,6 +69,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          MAPEO_VARIANT: ${{ matrix.variant }}
+      - name: Publish (unsigned)
+        if: github.repository != 'digidem/mapeo-desktop'
+        run: |
+          npm run dist -- --${{matrix.config.arch}}
+        env:
+          CI: true
           MAPEO_VARIANT: ${{ matrix.variant }}
       - name: Cleanup artifacts
         run: |


### PR DESCRIPTION
Currently CI will break if run on a PR from a fork. This is because
the secrets are passed as empty strings, and electron-builder sees this
as "not null" so still tries to sign the installers.

This change ensures that the environment variables are not set when
the Github action is triggered from a forked repo, so that electron
builder just builds an un-signed installer.

We will not be able to fully test this here. We can ensure that the normal path still runs - e.g. generating signed installers from internal PRs - but we will need to merge and then PR from a fork to check this actually fixes things.