### PR TITLE
chore: bump mapeo-config-icca@1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23924,9 +23924,9 @@
       }
     },
     "mapeo-config-icca": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/mapeo-config-icca/-/mapeo-config-icca-1.4.0.tgz",
-      "integrity": "sha512-Yg0AXgJoUeNejwaIrO2ockISve0r3PzRSLhpV6pIt1UYkyplEQKidAO1YRvl4Az02Pkfw/lk6ioAj8upvE70mQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mapeo-config-icca/-/mapeo-config-icca-1.6.0.tgz",
+      "integrity": "sha512-Qosice2ZCeTr3KYZjHPGP1eBWFa+VxARS3uw10Di5jNSl8OwEZuuYkxAwv/RZowYqWMw6UVYksXaznkEqXVopA==",
       "dev": true
     },
     "mapeo-default-settings": {

--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
     "jest": "^24.9.0",
     "license-check": "^1.1.5",
     "lint-staged": "^11.1.2",
-    "mapeo-config-icca": "^1.4.0",
+    "mapeo-config-icca": "^1.6.0",
     "mock-data": "^1.5.5",
     "npm-run-all": "^4.0.0",
     "patch-package": "^6.2.0",


### PR DESCRIPTION
Should only change the Mapeo for ICCAs release - this is not included in the general Mapeo release.