### PR TITLE
fix: fix translations of presets in territory view

### DIFF
--- a/src/renderer/components/MapEditor/index.js
+++ b/src/renderer/components/MapEditor/index.js
@@ -114,16 +114,16 @@ insertCss(`
   .id-container .inspector-body .raw-membership-editor {
     display: none;
   }
-  
-  .id-container .save-success .link-out { 
+
+  .id-container .save-success .link-out {
     display: none;
   }
-  .id-container .save-success .summary-table { 
+  .id-container .save-success .summary-table {
     display: none;
   }
   .id-container .layer-list li.switch {
     background: none;
-  }  
+  }
   .id-container .map-panes .imagery-faq {
     display: none;
   }
@@ -311,8 +311,9 @@ const MapEditor = () => {
         translations[Object.keys(translations)[0]] ||
         {}
       if (translationsInLocale.presets) {
-        ;(iD.translations[currentLocale] || iD.translations.en).presets =
-          translationsInLocale.presets
+        ;(
+          iD.translations[currentLocale] || iD.translations.en
+        ).presets = translationsInLocale
       }
     }
     if (presets) {


### PR DESCRIPTION
Presets with translations in multiple languages (e.g. the default config presets that we ship with Mapeo) were only showing up in English in the Territory view, ignoring the selected locale of Mapeo.

**Before:**

<img width="910" alt="Screenshot 2022-05-19 at 14 02 49" src="https://user-images.githubusercontent.com/290457/169300228-08d13131-2d26-48b9-8cce-e6202f2ead44.png">

The default presets are already translated. This PR fixes a bug in the code that added the translations to iD Editor.

**After:**

<img width="934" alt="Screenshot 2022-05-19 at 14 02 15" src="https://user-images.githubusercontent.com/290457/169300367-e1457629-386d-4588-bf36-148e5e829bf9.png">

