### PR TITLE
add dev instructions to wait before running dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ npm run build:translations
 npm run watch
 ```
 
+Before proceeding, you will have to wait until some background processes have culminated. You will know this has taken place when you see terminal output indicating that your app (and assets such as translations) have been built.
+
 Then, in another terminal, run the app in development mode:
 
 ```sh


### PR DESCRIPTION
I added a line to the README indicating to wait for `npm run watch` to culminate before running ` npm run build`. 