### PR TITLE
fix: strict identification of ISO dates

### DIFF
--- a/src/renderer/components/MapFilter/lib/data_analysis/statistics.js
+++ b/src/renderer/components/MapFilter/lib/data_analysis/statistics.js
@@ -76,7 +76,11 @@ function addItemStats (item: JSONObject = {}, stats: Statistics) {
   flatObjectEntries(item).forEach(function ([path, value]) {
     const key = JSON.stringify(path)
     if (!stats[key]) stats[key] = defaultStats()
-    addFieldStats(value, stats[key])
+    try {
+      addFieldStats(value, stats[key])
+    } catch (e) {
+      console.error('Error adding field stats for value %s', value, e)
+    }
   })
 }
 

--- a/src/renderer/components/MapFilter/lib/data_analysis/statistics.js
+++ b/src/renderer/components/MapFilter/lib/data_analysis/statistics.js
@@ -151,6 +151,7 @@ function addNumberStats (value: number, stats: NumberStatistic) {
 
 function addDateTimeStats (value: string, stats: DateStatistic) {
   const dateAsNumber = +Date.parse(value)
+  if (isNaN(dateAsNumber)) return // ignore invalid dates
   stats.count += 1
   const { mean } = statReduce(
     {

--- a/src/renderer/components/MapFilter/lib/data_analysis/value_types.js
+++ b/src/renderer/components/MapFilter/lib/data_analysis/value_types.js
@@ -44,7 +44,7 @@ export function guessValueType (
 
   // Test date last because this is the most expensive
   if (isShortDate(value)) return valueTypes.DATE
-  if (isodate.is(value)) return valueTypes.DATETIME
+  if (isodate.is(value, true)) return valueTypes.DATETIME
 
   return valueTypes.STRING
 }

--- a/src/renderer/components/MapFilter/lib/data_analysis/value_types.js
+++ b/src/renderer/components/MapFilter/lib/data_analysis/value_types.js
@@ -44,7 +44,8 @@ export function guessValueType (
 
   // Test date last because this is the most expensive
   if (isShortDate(value)) return valueTypes.DATE
-  if (isodate.is(value, true)) return valueTypes.DATETIME
+  if (isodate.is(value, true) && !isNaN(Date.parse(value)))
+    return valueTypes.DATETIME
 
   return valueTypes.STRING
 }


### PR DESCRIPTION
The observation view calculates statistics for each field for all observations. This calculation relies on guessing the type of each value. For ISO dates, we are using [`@segment/isodate`](https://www.npmjs.com/package/@segment/isodate) but were not enabling strict mode, which meant that four-digit numbers like `2013` were evaluated as an ISO date, and also ranges like `1000-3000` were considered "ISO dates", however none of these types of dates can be parsed by `Date.parse()`, which results in an uncaught error when trying to calculate statistics for a field.

The fix for this is to enable strict ISO date checking, and to also catch values that `Date.parse()` cannot parse.